### PR TITLE
fix transit vehicle config

### DIFF
--- a/addons/cars/functions/fnc_spawnCarAndCrew.sqf
+++ b/addons/cars/functions/fnc_spawnCarAndCrew.sqf
@@ -11,7 +11,7 @@ params [
 ];
 
 if (_vehicleClass == "") then {
-    private _vehicleClasses = parseSimpleArray ([QGVAR(vehicles)] call CBA_settings_fnc_get);
+    private _vehicleClasses = [[QGVAR(vehicles)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
     if (_vehicleClasses isEqualTo []) exitWith {
         WARNING("will not spawn vehicles as zero vehicle classes are defined");
     };

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -1,3 +1,4 @@
 PREP(augmentStateMachine);
 PREP(registerCivTaskType);
 PREP(civGetState);
+PREP(parseCsv);

--- a/addons/common/functions/fnc_parseCsv.spec.sqf
+++ b/addons/common/functions/fnc_parseCsv.spec.sqf
@@ -1,0 +1,36 @@
+[
+    "GIVEN parseCsv func",
+    {
+        grad_civs_common_fnc_parseCsv
+    },
+    [
+        ["WHEN I pass an empty string",
+            { "" call _this },
+            [["THEN it will return empty array", { [_this, []] call grad_testing_fnc_assertEquals; }]]
+        ],
+        ["WHEN I pass brackets",
+            { "[]" call _this },
+            [["THEN it will return empty array", { [_this, []] call grad_testing_fnc_assertEquals; }]]
+        ],
+        ["WHEN I pass a stringified mixed array",
+            { "[""hello"",false,""where,are,you"",4]" call _this },
+            [["THEN it will return the parsed array", { [_this, ["hello", false, "where,are,you",4]] call grad_testing_fnc_assertEquals; }]]
+        ],
+        ["WHEN I pass a stringified string array",
+            { "[""hello"",""where,are,you""]" call _this },
+            [["THEN it will return the parsed array", { [_this, ["hello", "where,are,you"]] call grad_testing_fnc_assertEquals; }]]
+        ],
+        ["WHEN I pass a comma separated quoted list with commas in the values",
+            { """hello"",""where,are,you""" call _this },
+            [["THEN it will return the parsed list", { [_this, ["hello", "where,are,you"]] call grad_testing_fnc_assertEquals; }]]
+        ],
+        ["WHEN I pass a mixed comma separated unquoted list",
+            { "hello,false,where,are,you,6" call _this },
+            [["THEN it will return the list, every value a string", { [_this, ["hello", "false", "where","are","you","6"]] call grad_testing_fnc_assertEquals; }]]
+        ],
+        ["WHEN I pass a numeric comma separated unquoted list",
+            { "1,3,3,7" call _this },
+            [["THEN it will return the list, every value a number", { [_this, [1,3,3,7]] call grad_testing_fnc_assertEquals; }]]
+        ]
+    ]
+] call grad_testing_fnc_executeTest;

--- a/addons/common/functions/fnc_parseCsv.sqf
+++ b/addons/common/functions/fnc_parseCsv.sqf
@@ -1,0 +1,33 @@
+#include "..\script_component.hpp"
+
+/*
+    parse list of strings
+*/
+params [
+    ["_rawValue", "", [""]]
+];
+
+private _delimiter = ",";
+
+private _firstChar = _rawValue select [0, 1];
+if (_firstChar == "") exitWith {[]};
+
+private _firstCharCode = (toArray _firstChar)#0;
+
+switch (_firstChar) do {
+    case ("["): { // assume stringified array
+        parseSimpleArray _rawValue
+    };
+    case (""""): { // assume quoted list. add brackets and parse as array.
+        parseSimpleArray (format ["[%1]",_rawValue])
+    };
+    default {
+        if (_firstCharCode >= 48 && _firstCharCode <= 57) then { // assume numbers. add brackets and parse as array.
+                parseSimpleArray (format ["[%1]",_rawValue])
+        } else {
+            (_rawValue splitString _delimiter) apply {
+                [_x] call CBA_fnc_trim
+            }
+        };
+    };
+};

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
@@ -50,7 +50,7 @@ private _addVars = {
 		["_civ", objNull]
 	];
 	private _fastSpeed = _civ getSpeed "FAST";
-	private _panicCooldown = parseSimpleArray ([QGVAR(panicCooldown)] call cba_settings_fnc_get); // TODO safe parsing
+	private _panicCooldown = [[QGVAR(panicCooldown)] call cba_settings_fnc_get] call EFUNC(common,parseCsv);
 	_civ setVariable["GRAD_CIVS_PANICCOOLDOWN" , random _panicCooldown, true];
 	_civ setVariable["grad_civs_runspeed", random [_fastSpeed * 0.5, _fastSpeed, _fastSpeed * 1.3], true];
 	_civ setVariable["grad_civs_recklessness", random [0, 5, 10], true];

--- a/addons/loadout/functions/fnc_applyRandomConfigArrayValue.sqf
+++ b/addons/loadout/functions/fnc_applyRandomConfigArrayValue.sqf
@@ -8,22 +8,7 @@ params [
 
 scopeName "main";
 private _rawValue = [_configVarname] call cba_settings_fnc_get;
-private _arrValue = [];
-switch (typeName _rawValue) do {
-    case ("STRING"): {
-        if (_rawValue == "") then {
-            breakOut "main";
-        };
-        _arrValue = parseSimpleArray _rawValue;
-    };
-    case ("ARRAY"): {
-        _arrValue = _rawValue;
-    };
-    default {
-        ERROR_2("unexpected type %1 for config %2", typeName _rawValue, _configVarname);
-        breakOut "main";
-    };
-};
+private _arrValue = [_rawValue] call EFUNC(common,parseCsv);
 
 if (count _arrValue == 0) exitWith {};
 

--- a/addons/patrol/XEH_postInit.sqf
+++ b/addons/patrol/XEH_postInit.sqf
@@ -15,7 +15,7 @@ if (isServer || !hasInterface) then {
         }
     ] call CBA_fnc_addEventHandler;
 
-    private _spawnDistances = parseSimpleArray ([QGVAR(spawnDistancesOnFoot)] call CBA_settings_fnc_get);
+    private _spawnDistances = [[QGVAR(spawnDistancesOnFoot)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
     [
         "patrol",
         _spawnDistances#1 * 1.5

--- a/addons/patrol/functions/fnc_addFootsy.sqf
+++ b/addons/patrol/functions/fnc_addFootsy.sqf
@@ -4,7 +4,7 @@ params [
     ["_allPlayers", []]
 ];
 
-private _footSpawnDistances = parseSimpleArray ([QGVAR(spawnDistancesOnFoot)] call CBA_settings_fnc_get);
+private _footSpawnDistances = [[QGVAR(spawnDistancesOnFoot)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
 private _footSpawnDistanceMin = _footSpawnDistances#0;
 private _footSpawnDistanceMax = _footSpawnDistances#1;
 

--- a/addons/residents/XEH_postInit.sqf
+++ b/addons/residents/XEH_postInit.sqf
@@ -15,7 +15,7 @@ if (isServer || !hasInterface) then {
         }
     ] call CBA_fnc_addEventHandler;
 
-    private _spawnDistances = parseSimpleArray ([QGVAR(spawnDistancesResidents)] call CBA_settings_fnc_get);
+    private _spawnDistances = [[QGVAR(spawnDistancesResidents)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
     [
         "reside",
         _spawnDistances#1 * 1.2

--- a/addons/residents/functions/fnc_addResident.sqf
+++ b/addons/residents/functions/fnc_addResident.sqf
@@ -4,7 +4,7 @@ params [
     ["_allPlayers", []]
 ];
 
-private _residentSpawnDistances = parseSimpleArray ([QGVAR(spawnDistancesResidents)] call CBA_settings_fnc_get);
+private _residentSpawnDistances = [[QGVAR(spawnDistancesResidents)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
 private _residentSpawnDistanceMin = _residentSpawnDistances#0;
 private _residentSpawnDistanceMax = _residentSpawnDistances#1;
 

--- a/addons/transit/README.md
+++ b/addons/transit/README.md
@@ -1,3 +1,10 @@
 # grad\_civs\_transit
 
 Add transit routes along which cvilians travel the whole width of the map
+
+## configuration notes
+
+vehicle classes being used are with falling priority:
+* in  the "transitSource" module in 3DEN
+* in the CBA settings for GRAD Civs/transit
+* in the CBA settings for GRAD Civs/cars

--- a/addons/transit/functions/fnc_addTransitRoute.sqf
+++ b/addons/transit/functions/fnc_addTransitRoute.sqf
@@ -5,19 +5,22 @@ params [
     ["_sourceDir", 0, [0]],
     ["_sinks", [], [[]]],
     ["_interval", 60, [0]],
-    ["_vehicles", [], [[]]]
+    ["_vehicleClasses", [], [[]]]
 ];
 
 assert(isServer);
 
 scopeName "main";
 
-if (_vehicles isEqualTo []) then {
-    private _vehicles = parseSimpleArray ([QEGVAR(cars,vehicles)] call CBA_settings_fnc_get);
-    if (_vehicles isEqualTo []) then {
-        WARNING("will not spawn vehicles as zero vehicle classes are defined");
-        breakOut "main";
-    };
+if (_vehicleClasses isEqualTo []) then {
+    _vehicleClasses = [[QGVAR(vehicles)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
+};
+if (_vehicleClasses isEqualTo []) then {
+    _vehicleClasses = [[QEGVAR(cars,vehicles)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
+};
+if (_vehicleClasses isEqualTo []) then {
+    WARNING_1("will not spawn vehicles in transit source %1 as no vehicle classes are defined anywhere");
+    breakOut "main";
 };
 
 assert(_interval > 0);
@@ -34,7 +37,7 @@ _newRoute setVariable ["source", _source, true];
 _newRoute setVariable ["sourceDir", _sourceDir, true];
 _newRoute setVariable ["sinks", _sinks, true];
 _newRoute setVariable ["interval", _interval, true];
-_newRoute setVariable ["vehicles", _vehicles, true];
+_newRoute setVariable ["vehicles", _vehicleClasses, true];
 _newRoute setVariable ["lastSpawn", -999999, true];
 
 GVAR(transitRoutes) pushBack _newRoute;

--- a/addons/transit/functions/fnc_addTransitVehicle.sqf
+++ b/addons/transit/functions/fnc_addTransitVehicle.sqf
@@ -3,17 +3,15 @@
 params [
     ["_pos", [], [[]]],
     ["_dir", 0, [0]],
+    ["_vehicleClasses", [], [[]]],
     ["_destination", [], [[]]]
 ];
 
 assert(count _pos > 1);
 assert(count _destination > 1);
 
-scopeName "main";
-
-private _vehicleClasses = parseSimpleArray ([QGVAR(vehicles)] call CBA_settings_fnc_get);
 if (_vehicleClasses isEqualTo []) exitWith {
-    WARNING("will not spawn vehicles as zero vehicle classes are defined");
+    WARNING_2("will not spawn vehicles as zero vehicle classes are defined for route from %1 to %2", _pos, _destination);
 };
 private _vehicleClass = selectRandom _vehicleClasses;
 

--- a/addons/transit/functions/fnc_initConfig.sqf
+++ b/addons/transit/functions/fnc_initConfig.sqf
@@ -14,3 +14,14 @@ private _settingsGroup = ["GRAD Civs", "9) transit"];
     {},
     false
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(vehicles),
+    "EDITBOX",
+    "Vehicle classes for transit (optional)",
+    _settingsGroup,
+    "[]",
+    true,
+    {},
+    false
+] call CBA_fnc_addSetting;

--- a/addons/transit/functions/fnc_module_transitSource.sqf
+++ b/addons/transit/functions/fnc_module_transitSource.sqf
@@ -18,14 +18,7 @@ switch _mode do {
             _x isKindOf QGVAR(transitSink)
         };
 
-		private _vics = _logic getVariable "Vehicles";
-		if (_vics isEqualType "") then {
-			if (_vics == "") then  {
-				_vics = [];
-			} else {
-				_vics = parseSimpleArray (_logic getVariable "Vehicles");
-			};
-		};
+		private _vics = [_logic getVariable ["Vehicles", ""]] call EFUNC(common,parseCsv);
 
 		[
 			getPos _logic,

--- a/addons/transit/functions/fnc_sm_business_trans_mountUp_transit_condition.sqf
+++ b/addons/transit/functions/fnc_sm_business_trans_mountUp_transit_condition.sqf
@@ -1,5 +1,15 @@
-private _isLeader = (leader _this) == _this;
-private _vehicle = vehicle _this;
-private _allMounted = ((units _this) findIf { vehicle _x != _vehicle}) == -1;
+private _civ = _this;
 
-_isLeader && _allMounted && (_this getVariable ["grad_civs_primaryTask", ""] == "transit")
+private _isLeader = (leader _civ) == _civ;
+
+private _allMounted = {
+    private _units = units _civ;
+    private _mountedUnits = crew vehicle _civ;
+    _units arrayIntersect _mountedUnits) isEqualTo _units
+};
+
+private _isTaskTransit = {
+    _civ getVariable ["grad_civs_primaryTask", ""] == "transit"
+};
+
+_isLeader && _allMounted && _isTaskTransit

--- a/addons/transit/functions/fnc_spawnSomething.sqf
+++ b/addons/transit/functions/fnc_spawnSomething.sqf
@@ -15,8 +15,9 @@ _route setVariable ["lastSpawn", CBA_missionTime, true];
 private _source = _route getVariable ["source", [0, 0, 0]];
 private _sourceDir = _route getVariable ["sourceDir", 0];
 private _sinks = _route getVariable ["sinks", []];
+private _vehicleClasses = _route getVariable ["vehicles", []];
 if (_sinks isEqualTo []) exitWith {
     ERROR_2("no sinks for transit route %1 starting at %2", _route. _source);
 };
 
-[_source, _sourceDir, selectRandom _sinks] call FUNC(addTransitVehicle);
+[_source, _sourceDir, _vehicleClasses, selectRandom _sinks] call FUNC(addTransitVehicle);

--- a/addons/voyage/XEH_postInit.sqf
+++ b/addons/voyage/XEH_postInit.sqf
@@ -15,7 +15,7 @@ if (isServer || !hasInterface) then {
         }
     ] call CBA_fnc_addEventHandler;
 
-    private _spawnDistances = parseSimpleArray ([QGVAR(spawnDistancesInVehicles)] call CBA_settings_fnc_get);
+    private _spawnDistances = [[QGVAR(spawnDistancesInVehicles)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
     [
         "voyage",
         _spawnDistances#1 * 1.5

--- a/addons/voyage/functions/fnc_addCarCrew.sqf
+++ b/addons/voyage/functions/fnc_addCarCrew.sqf
@@ -7,7 +7,7 @@ params [
 
 scopeName "main";
 
-private _vehicleSpawnDistances = parseSimpleArray ([QGVAR(spawnDistancesInVehicles)] call CBA_settings_fnc_get);
+private _vehicleSpawnDistances = [[QGVAR(spawnDistancesInVehicles)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
 private _vehicleSpawnDistanceMin = _vehicleSpawnDistances#0;
 private _vehicleSpawnDistanceMax = _vehicleSpawnDistances#1;
 


### PR DESCRIPTION
* allow CSV-style config lists. these all are valid:
    ```
	  ["a", "b"]
	  "a","b"
	  a,b
    ```
* fix vehicle classes config for transit - now its
	  `3den module > transit addon > cars addon`
* probably fix mountUp->transit condition
  Here, cars started to move while units were disembarked (or disembarking?).
  My guess: `crew` is more accurate than `vehicle`
* optimize mountUp->transit condition