### PR TITLE
fix #39 once and for all

### DIFF
--- a/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
@@ -1,8 +1,7 @@
 #include "..\script_component.hpp"
 
 private _group = group _this;
-private _wpidx = currentWaypoint _group;
 private _wps = waypoints _group;
-private _wppos = waypointPosition (_wps select _wpidx);
+private _wppos = waypointPosition (_wps select (currentWaypoint _group));
 
-[_this,  format ["traveling to waypoint %1, %2 (%3m left)", _wpidx, _wppos, _this distance _wppos]] call EFUNC(legacy,setCurrentlyThinking);
+[_this,  format ["traveling to waypoint %1, %2 (%3m left)", currentWaypoint _group, _wppos, _this distance _wppos]] call EFUNC(legacy,setCurrentlyThinking);


### PR DESCRIPTION
...provided SQF execution does not suspend within a single statement.

By putting everything array selection into a single statement, the index should not be getting stale anymore between one line and the next.