### PR TITLE
various bugfixes & clean ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ maxCivsOnFoot            | 30            | Maximum number of civs on foot.
 maxCivsResidents         | 20            | Maximum number of civs that are residents, mostly doing their thing at home.
 minCivUpdateTime         | 2             | Spawn new civilians only if their beheviour states get updated at least every N seconds. NOTE: each frame only one civ gets updated. Example: With 40fps and minCivUpdateTime=2, not more than 80 civs will be alive at any given time. This setting is meant to prevent civs from becoming too unresponsive.
 minFps                   | 40            | Spawn new civilians only if fps are at or above N . NOTE: the fps are taken from the machine that spawns the civs, which may be a HC.
-onHeldUp                 | ""            | Code to execute when civilian stops because a weapon is pointed at him. Passed parameters are: [civilian].
-onKilled                 | ""            | Code to execute when civilian is killed. Passed parameters are: [civilian,killer].
-onSpawn                  | ""            | Code to execute on civilian spawn. Passed parameters are: [civilian,vehicle (objNull if on foot)].
 panicCooldown            | [15,120,240]  | Time it takes until a civilian relaxes after panicking (trivariate: [lowest, median, highest])
 spawnDistancesInVehicles | [1500,6000]   | Minimum and maximum distance to players that civilians in vehicles can spawn in.
 spawnDistancesOnFoot     | [1000,4500]   | Minimum and maximum distance to players that civilians on foot can spawn in.

--- a/addons/legacy/functions/fnc_serverLoop.sqf
+++ b/addons/legacy/functions/fnc_serverLoop.sqf
@@ -6,6 +6,7 @@ ISNILS(GVAR(EXITON), {});
 
 private _mainLoop = {
     params ["_args", "_handle"];
+    if (!isGameFocused || isGamePaused) exitWith {};
 
     if (call GVAR(EXITON)) exitWith {
         INFO("exiting because GRAD_CIVS_EXITON returned true");
@@ -32,6 +33,7 @@ private _mainLoop = {
 
 GVAR(debugLoopHandle) = [{
     params ["_args", "_handle"];
+    if (!isGameFocused || isGamePaused) exitWith {};
     if (call GVAR(EXITON)) exitWith {[_handle] call CBA_fnc_removePerFrameHandler};
     if (([QGVAR(debugCivState)] call CBA_settings_fnc_get)) then {
         { _x call FUNC(updateInfoLine); } forEach GVAR(localCivs);
@@ -53,6 +55,7 @@ GVAR(debugLoopHandle) = [{
 [
     {
         GVAR(localCivs) = GVAR(localCivs) select {
+            // NOTE: do not handle `alive` here, we've got a transition & state for proper disposal of dead civilians
             if (isNull _x) then {
                 INFO_1("abandoning civilian they have become NULL (deleted?)", _x);
                 false

--- a/addons/legacy/functions/fnc_sm_activities_state_surrendered_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_activities_state_surrendered_enter.sqf
@@ -1,6 +1,5 @@
 #include "..\script_component.hpp"
 
-[_this] call GRAD_CIVS_ONHELDUP;
 _this setVariable ["grad_civs_surrenderTime", CBA_missionTime];
 [_this, true] call ACE_captives_fnc_setSurrendered;
 _this disableAI "MOVE";

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_death_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_death_enter.sqf
@@ -6,7 +6,7 @@ private _killer = _this getVariable ["ace_medical_lastDamageSource", objNull];
 // old killed event to be used with publicVariable EH
 // DEPRECATED
 CIV_KILLED = [_deathPos, _killer];
-INFO_1("civ killed: %1", CIV_KILLED);
+INFO_2("civ killed at %1 by %2", _deathPos, _killer);
 publicVariableServer "CIV_KILLED";
 
 // new killed event to be used with config

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_death_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_death_enter.sqf
@@ -3,17 +3,9 @@
 private _deathPos = getPos _this;
 private _killer = _this getVariable ["ace_medical_lastDamageSource", objNull];
 
-// old killed event to be used with publicVariable EH
-// DEPRECATED
-CIV_KILLED = [_deathPos, _killer];
-INFO_2("civ killed at %1 by %2", _deathPos, _killer);
-publicVariableServer "CIV_KILLED";
+INFO_2("releasing civ killed at %1 by %2", _deathPos, _killer);
 
-// new killed event to be used with config
-[_this, _killer] call GRAD_CIVS_ONKILLED;
-
-// even newer CBA event magic
-["grad_civs_civKilled", CIV_KILLED] call CBA_fnc_globalEvent;
+["grad_civs_civKilled", [_deathPos, _killer]] call CBA_fnc_globalEvent;
 
 GVAR(localCivs) = GVAR(localCivs) - [_this];
 ["grad_civs_civ_removed", [_this]] call CBA_fnc_globalEvent;

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_death_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_death_enter.sqf
@@ -2,8 +2,9 @@
 
 private _deathPos = getPos _this;
 private _killer = _this getVariable ["ace_medical_lastDamageSource", objNull];
+_this setVariable ["grad_civs_livedAs", str _this, true]; // as dead units dont have a group - or the group mightve been deleted since - this var is my only way to identify the body later on
 
-INFO_2("releasing civ killed at %1 by %2", _deathPos, _killer);
+INFO_3("releasing civ %1 killed at %2 by %3", _this, _deathPos, _killer);
 
 ["grad_civs_civKilled", [_deathPos, _killer]] call CBA_fnc_globalEvent;
 

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
@@ -58,10 +58,6 @@ private _addVars = {
 
 _unit enableDynamicSimulation true;
 
-ISNILS(GRAD_CIVS_ONSPAWN, {}); // TODO trigger event instead
-[_unit] call GRAD_CIVS_ONSPAWN;
-
-
 _unit setVariable ["asr_ai_exclude", true];
 
 [_unit] call _addKilledNews;

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
@@ -58,7 +58,7 @@ private _addVars = {
 
 _unit enableDynamicSimulation true;
 
-_unit setVariable ["asr_ai_exclude", true];
+_unit setVariable ["asr_ai_exclude", true, true];
 
 [_unit] call _addKilledNews;
 [_unit] call _addGunfightNewsAndFlee;

--- a/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_state_spawn_enter.sqf
@@ -24,6 +24,7 @@ private _addKilledNews = {
    (_this select 0) addEventHandler ["Killed",
     {
 		params ["_unit"];
+		INFO_2("civ %1 was killed (index: %2), firing internal 'killed' event", _unit, GVAR(localCivs) find _unit);
 
 		["killed", [_unit], [_unit]] call CBA_fnc_targetEvent;
 

--- a/addons/legacy/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
@@ -3,7 +3,7 @@
 if (CBA_missionTime - (_this getVariable [QGVAR(lastDespawnCheck), 0]) < 10) exitWith {};
 _this setVariable [QGVAR(lastDespawnCheck), CBA_missionTime];
 
-INFO_1("check despawn cond for %1", _this);
+LOG_1("check despawn cond for %1", _this);
 
 if (_this getVariable ["grad_civs_excludeFromCleanup",false]) exitWith {false};
 

--- a/addons/legacy/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
@@ -1,14 +1,11 @@
 #include "..\script_component.hpp"
 
-private _idx =  GVAR(localCivs) find _this;
+if (CBA_missionTime - (_this getVariable [QGVAR(lastDespawnCheck), 0]) < 10) exitWith {};
+_this setVariable [QGVAR(lastDespawnCheck), CBA_missionTime];
 
-if (_idx == -1) exitWith {false}; // should not happen, really
-
-if (((floor CBA_missionTime) mod 10) != (_idx mod 10)) exitWith {false}; // check only every 10s for a given unit
+INFO_1("check despawn cond for %1", _this);
 
 if (_this getVariable ["grad_civs_excludeFromCleanup",false]) exitWith {false};
-
-scopeName "main";
 
 private _type = _this getVariable ["grad_civs_primaryTask", ""];
 private _civTaskTypeInfo = EGVAR(common,civTaskTypes) getVariable [_type, []];
@@ -20,9 +17,8 @@ _civTaskTypeInfo params [
 private _tooDistantFromPlayers = false;
 if ((count ALL_HUMAN_PLAYERS > 0) || ([QGVAR(spawnOnlyWithPlayers)] call CBA_settings_fnc_get)) then {
     if ([ALL_HUMAN_PLAYERS, getPos _this, _cleanupDistance] call FUNC(isInDistanceFromOtherPlayers)) then {
-        INFO("despawning civ based on distance");
+        INFO_1("despawning civ %1 based on distance", _this);
         _tooDistantFromPlayers = true;
-        breakTo "main";
     };
 } else {
     INFO("no human players connected, but civs allowed - will abstain from despawning civilians based on player distance");

--- a/addons/legacy/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
+++ b/addons/legacy/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
@@ -17,13 +17,15 @@ _civTaskTypeInfo params [
     ["_despawnCondition", {false}, [{}]]
 ];
 
+private _tooDistantFromPlayers = false;
 if ((count ALL_HUMAN_PLAYERS > 0) || ([QGVAR(spawnOnlyWithPlayers)] call CBA_settings_fnc_get)) then {
     if ([ALL_HUMAN_PLAYERS, getPos _this, _cleanupDistance] call FUNC(isInDistanceFromOtherPlayers)) then {
         INFO("despawning civ based on distance");
-        breakOut "main";
+        _tooDistantFromPlayers = true;
+        breakTo "main";
     };
 } else {
     INFO("no human players connected, but civs allowed - will abstain from despawning civilians based on player distance");
 };
 
-_this call _despawnCondition
+_tooDistantFromPlayers || {_this call _despawnCondition}

--- a/addons/legacy/functions/fnc_spawnPass.sqf
+++ b/addons/legacy/functions/fnc_spawnPass.sqf
@@ -8,7 +8,7 @@ private _minCivUpdateTime = [QGVAR(minCivUpdateTime)] call cba_settings_fnc_get;
 private _minFps = [QGVAR(minFps)] call cba_settings_fnc_get;
 
 private _fps = diag_fps;
-if (_fps < _minFps) exitWith {INFO_2("not spawning additional civs: less FPS than required (%1/%2)", _fps, _minFps)};
-if ((_fps * _minCivUpdateTime) < (count GVAR(localCivs))) exitWith {INFO_3("not spawning additional civs: cannot guarantee update times less than %1 for %2 civs with %3 fps", _minCivUpdateTime, count GVAR(localCivs), _fps)};
+if (_fps < _minFps) exitWith {LOG_2("not spawning additional civs: less FPS than required (%1/%2)", _fps, _minFps)};
+if ((_fps * _minCivUpdateTime) < (count GVAR(localCivs))) exitWith {LOG_3("not spawning additional civs: cannot guarantee update times less than %1 for %2 civs with %3 fps", _minCivUpdateTime, count GVAR(localCivs), _fps)};
 
 [QGVAR(spawnAllowed), []] call CBA_fnc_localEvent;

--- a/addons/patrol/functions/fnc_taskPatrol.sqf
+++ b/addons/patrol/functions/fnc_taskPatrol.sqf
@@ -13,14 +13,14 @@
 */
 
 params [
-    ["_groupOrUnit", grpNull],
-    ["_centerPositionOrObject", [0, 0, 0]],
-    ["_radius", 0],
-    ["_count", 3],
-    ["_timeout",[0,0,0]],
-    ["_findPosOfInterest",false],
-    ["_findRoadPos",false],
-    ["_findWaterPos",false]
+    ["_groupOrUnit", grpNull, [grpNull]],
+    ["_centerPositionOrObject", [0, 0, 0], [[0, 0, 0]]],
+    ["_radius", 0, [0, [0, 0]]],
+    ["_count", 3, [0, [0, 0]]],
+    ["_timeout",[0,0,0], [[0, 0, 0]]],
+    ["_findPosOfInterest",false, [false]],
+    ["_findRoadPos",false, [false]],
+    ["_findWaterPos",false, [false]]
 ];
 
 private _clearWaypoints =  {
@@ -34,8 +34,8 @@ private _clearWaypoints =  {
 
 private _group = if (typeName _groupOrUnit == "OBJECT") then {group _groupOrUnit} else {_groupOrUnit};
 private _centerPosition = if (typeName _centerPositionOrObject == "OBJECT") then {getPos _centerPositionOrObject} else {_centerPositionOrObject};
-_radius = if (typeName _radius == "ARRAY") then {(random ((_radius select 1) - (_radius select 0))) + (_radius select 1)} else {_radius};
-_count = if (typeName _count == "ARRAY") then {(random ((_count select 1) - (_count select 0))) + (_count select 1)} else {_count};
+_radius = if (typeName _radius == "ARRAY") then {(random ((_radius select 1) - (_radius select 0))) + (_radius select 0)} else {_radius};
+_count = if (typeName _count == "ARRAY") then {(random ((_count select 1) - (_count select 0))) + (_count select 0)} else {_count};
 private _position = _centerPosition;
 
 assert(_count > 0);

--- a/addons/patrol/functions/fnc_taskPatrol.sqf
+++ b/addons/patrol/functions/fnc_taskPatrol.sqf
@@ -13,8 +13,8 @@
 */
 
 params [
-    ["_groupOrUnit", grpNull, [grpNull]],
-    ["_centerPositionOrObject", [0, 0, 0], [[0, 0, 0]]],
+    ["_groupOrUnit", grpNull, [grpNull, objNull]],
+    ["_centerPositionOrObject", [0, 0, 0], [objNull, [0, 0, 0]]],
     ["_radius", 0, [0, [0, 0]]],
     ["_count", 3, [0, [0, 0]]],
     ["_timeout",[0,0,0], [[0, 0, 0]]],

--- a/addons/transit/functions/fnc_sm_lifecycle.sqf
+++ b/addons/transit/functions/fnc_sm_lifecycle.sqf
@@ -12,5 +12,5 @@ assert ([
     _lifecycle_life, _lifecycle_despawn,
     { _this call FUNC(sm_lifecycle_trans_life_despawn_condition) },
     {},
-    _lifecycle_life + _lifecycle_despawn
+    "transit_" + _lifecycle_life + _lifecycle_despawn
 ] call EFUNC(cba_statemachine,addTransition));

--- a/addons/voyage/functions/fnc_initConfig.sqf
+++ b/addons/voyage/functions/fnc_initConfig.sqf
@@ -25,3 +25,14 @@ private _settingsGroup = ["GRAD Civs", "6) voyagers"];
     {},
     false
 ] call CBA_fnc_addSetting;
+
+[
+    QGVAR(maxTravelRadius),
+    "SLIDER",
+    "max travel radius around spawn (otional)",
+    _settingsGroup,
+    [0, 100000, 0, 0],
+    false,
+    {},
+    false
+] call CBA_fnc_addSetting;

--- a/addons/voyage/functions/fnc_sm_business_state_voyage_enter.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_enter.sqf
@@ -1,6 +1,12 @@
 #include "..\script_component.hpp"
 
-[_this, _this, 2500, 3, [0,0,0], false, true] call EFUNC(patrol,taskPatrol); // vehicle patrol: wide range
+private _maxTravelRadius = [QGVAR(maxTravelRadius)] call CBA_settings_fnc_get;
+if (_maxTravelRadius <= 0) then {
+    private _vehicleSpawnDistances = [[QGVAR(spawnDistancesInVehicles)] call CBA_settings_fnc_get] call EFUNC(common,parseCsv);
+    _maxTravelRadius = _vehicleSpawnDistances#1;
+};
+
+[_this, _this, _maxTravelRadius, 3, [0,0,0], false, true] call EFUNC(patrol,taskPatrol); // vehicle patrol: wide range
 _this setSpeedMode "LIMITED";
 _this forceSpeed -1;
 _this enableDynamicSimulation true;

--- a/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
@@ -1,6 +1,9 @@
 #include "..\script_component.hpp"
 
 private _group = group _this;
+if (isNull _group) exitWith {
+    WARNING_2("unit %1 in voyage loop has no group, will ignore. is it dead? :%2", _this, alive _this);
+};
 private _wps = waypoints _group;
 private _wppos = waypointPosition (_wps select (currentWaypoint _group));
 

--- a/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
@@ -2,7 +2,8 @@
 
 private _group = group _this;
 if (isNull _group) exitWith {
-    WARNING_2("unit %1 in voyage loop has no group, will ignore. is it dead? :%2", _this, alive _this);
+    private _livedAs = _this getVariable ["grad_civs_livedAs", str _this];
+    WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(legacy,localCivs) find _this, getPos _this);
 };
 private _wps = waypoints _group;
 private _wppos = waypointPosition (_wps select (currentWaypoint _group));


### PR DESCRIPTION
* do not run all the spawn & other loops while game is paused
* predictable despawn check every 10s for individual units
* remove old non-stackable events (all of them broken rn anyway)
* set `grad_civs_livedAs` on death so as to identify the body later even after group gets deleted
* fix ASR AI exclusion in the event of locality change
* fix distance despawn condition
* reduce log level of periodic tasks
* add optional config var for voyagers.: "maximum travel distance from spawn". defaults to max spawn distance from players. was fixed at 2500 before.