### PR TITLE
fix #92 (surrender after dismount)

### DIFF
--- a/addons/cars/functions/fnc_spawnCarAndCrew.sqf
+++ b/addons/cars/functions/fnc_spawnCarAndCrew.sqf
@@ -23,7 +23,7 @@ if (_vehicleClasses isEqualTo []) exitWith {
 
 _vehicleClass = selectRandom _vehicleClasses;
 
-_veh = [_pos, _vehicleClass] call FUNC(spawnVehicle);
+private _veh = [_pos, _vehicleClass] call FUNC(spawnVehicle);
 ["ace_common_setDir", [_veh, _dir], _veh] call CBA_fnc_targetEvent;
 
 private _maxInitialGroupSize = EGVAR(patrol,initialGroupSize);

--- a/addons/interact/functions/fnc_addInteractEventHandlers.sqf
+++ b/addons/interact/functions/fnc_addInteractEventHandlers.sqf
@@ -1,10 +1,11 @@
 #include "..\script_component.hpp"
 
 [QGVAR(pointed_at_inc), {
-    params ["_civ"];
+    params ["_civ", "_pointingPlayer"];
     if (_civ == ACE_player) exitWith {};
     private _currentCount = _civ getVariable [QGVAR(pointedAtCount), 0];
     _civ setVariable [QGVAR(pointedAtCount), _currentCount + 1, true];
+    _civ setVariable [QGVAR(pointingPlayer), _pointingPlayer]; // local is enough, used for immediate effect
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(pointed_at_dec), {

--- a/addons/interact/functions/fnc_checkWeaponOnCivilianPointer.sqf
+++ b/addons/interact/functions/fnc_checkWeaponOnCivilianPointer.sqf
@@ -23,7 +23,7 @@ private _point = {
             _counter = 2 min (_counter + 1);
             [GVAR(gunpointees), _x, _counter] call CBA_fnc_hashSet;
             if (_counter == 2) then {
-                [QGVAR(pointed_at_inc), [_x], [_x]] call CBA_fnc_targetEvent;
+                [QGVAR(pointed_at_inc), [_x, player], [_x]] call CBA_fnc_targetEvent;
                 [QGVAR(pointing), _x] call CBA_fnc_localEvent;
             };
         };

--- a/addons/interact/functions/fnc_sm_activities_state_surrendered_enter.sqf
+++ b/addons/interact/functions/fnc_sm_activities_state_surrendered_enter.sqf
@@ -1,6 +1,14 @@
 #include "..\script_component.hpp"
 
+private _pointingPlayer = _this getVariable [QGVAR(pointingPlayer), objNull];
+if !(isNull _pointingPlayer) then {
+	private _dirVector = (getPos _pointingPlayer) vectorDiff (getPos _this);
+	["ace_common_setVectorDirAndUp", [_this, [_dirVector, [0, 0, 1]]], _this] call CBA_fnc_targetEvent;
+};
+
 _this setVariable ["grad_civs_surrenderTime", CBA_missionTime];
 [_this, true] call ACE_captives_fnc_setSurrendered;
+
+// the issue is that after dismounting, unit will sprint around. "doStop" does not seem to reliably and immediately work
 _this disableAI "MOVE";
 _this disableAI "ANIM";

--- a/addons/interact/functions/fnc_sm_activities_state_surrendered_exit.sqf
+++ b/addons/interact/functions/fnc_sm_activities_state_surrendered_exit.sqf
@@ -4,3 +4,4 @@ _this enableAI "ANIM";
 _this enableAI "MOVE";
 [_this, false] call ACE_captives_fnc_setSurrendered;
 _this setVariable ["grad_civs_surrenderTime", nil];
+_this setVariable [QGVAR(pointingPlayer), nil];


### PR DESCRIPTION
the bug had two components, both of which are now fixed:
* passengers did not raise their hands if player did not immediately switch from targeting the vehicle to targeting the unit (a regression brought about in a major refactor some time ago)
* passengers kept their dismount orientation - thus often they could not see the pointing player, got unpointed because of that, and thus did not surrender