### PR TITLE
dont throw if state machine has not states variable yet. no idea how …

### DIFF
--- a/addons/cba_statemachine/functions/fnc_hasState.sqf
+++ b/addons/cba_statemachine/functions/fnc_hasState.sqf
@@ -7,8 +7,6 @@ params [
 
 assert(!(isNull _stateMachine));
 
-private _states = _stateMachine getVariable "cba_statemachine_states";
-if (isNil "_states") then {
-    throw "halp";
-};
+private _states = _stateMachine getVariable ["cba_statemachine_states", []];
+
 _state in _states


### PR DESCRIPTION
…that can happen tbh though

all members of `EGVAR(common,statemachines)`  are only set after theyve been initialized, and thats the only place the only caller of `hasState ` gets them from :/