### PR TITLE
remove hard ACE dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Spawn ambient civilians on the map.
 ## Features
 
 Automatically populate the map with civilians who live in their own houses, go for long walks and short chats with their nightbors, or drive around the country.
-Civilians can interact with players in various ways - surrendering when threatened with violence, hiding in panic when violence actually happens. 
+Civilians can interact with players in various ways - surrendering when threatened with violence, hiding in panic when violence actually happens.
 They will halt their cars if signaled to stop, or move out of the way when getting honked at. If you're lucky they will even back up their vehicles if being told to do so (known unreliable).
 Civilian *players* will get help trying to mimikry AI civilians by getting hints as to the interactions players perform that AI civilians would "notice".
 Mission makers can use a bunch of options to clothe their civilians, get CBA events to detect players stealing civilian vehicles, and can restrict civilians to certain areas of the map.
@@ -21,7 +21,7 @@ The mod is meant to make use of Headless Clients, no extra configuration necessa
 ## Dependencies
 
 * [CBA_A3](https://github.com/CBATeam/CBA_A3)
-* [ACE3](https://github.com/acemod/ACE3)
+* optional: [ACE3](https://github.com/acemod/ACE3)
 * optional: [ZEN](https://github.com/zen-mod/ZEN/) adds some context menus for Zeus
 * optional: [Gruppe Adler Mod](https://github.com/gruppe-adler/gruppe_adler_mod/) to enable having livestock onto trucks
 
@@ -39,7 +39,7 @@ Civilians on separate islands can run into pathing problems. Avoid by creating e
 
 ## Detailed documentation
 
-All modules have their own READMEs that describe features, settings & APIs: 
+All modules have their own READMEs that describe features, settings & APIs:
 
 * [activities](addons/activities/README.md)
 * [cars](addons/cars/README.md)
@@ -62,8 +62,8 @@ All modules have their own READMEs that describe features, settings & APIs:
 
 * we're using the CBA state machine implementation, see `addons/*/functions/fn_sm_*/`
 * there's also some extensions being done to the CBA state machnie implementation to allow for nested states and other shenanigans, see [`addons/cba_statemachine`](addons/cba_statemachine/README.md)
-* if you add states or transitions, do update the DOT files in `/docs` 
-* also, install [Graphviz](https://graphviz.gitlab.io/) and generate graphs using `dot -Tsvg states.gv > states.svg` etc or use an online editor   
+* if you add states or transitions, do update the DOT files in `/docs`
+* also, install [Graphviz](https://graphviz.gitlab.io/) and generate graphs using `dot -Tsvg states.gv > states.svg` etc or use an online editor
 
 ### State Machines
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The mod is meant to make use of Headless Clients, no extra configuration necessa
 ## Dependencies
 
 * [CBA_A3](https://github.com/CBATeam/CBA_A3)
-* optional: [ACE3](https://github.com/acemod/ACE3)
+* optional: [ACE3](https://github.com/acemod/ACE3) for some interactions
 * optional: [ZEN](https://github.com/zen-mod/ZEN/) adds some context menus for Zeus
 * optional: [Gruppe Adler Mod](https://github.com/gruppe-adler/gruppe_adler_mod/) to enable having livestock onto trucks
 

--- a/addons/activities/config.cpp
+++ b/addons/activities/config.cpp
@@ -6,7 +6,15 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"CBA_Extended_EventHandlers", "grad_civs_main", "grad_civs_common", "grad_civs_cba_statemachine"};
+        requiredAddons[] = {
+            "CBA_Extended_EventHandlers"
+            #ifdef WITH_ACE3_DEPENDENCY
+                , "ace_captives"
+            #endif
+            , "grad_civs_main"
+            , "grad_civs_common"
+            , "grad_civs_cba_statemachine"
+        };
         author = "AUTHOR";
         VERSION_CONFIG;
     };

--- a/addons/interact/XEH_postInit.sqf
+++ b/addons/interact/XEH_postInit.sqf
@@ -4,7 +4,12 @@ if (!(EGVAR(main,enabled))) exitWith {};
 
 if (hasInterface) then {
     call FUNC(aceInteractWrapper);
-    call FUNC(addCivInteractions);
+    if (isNil "ace_interact_menu_fnc_createAction") then {
+        WARNING("ACE interact not loaded - this limits interaction with civilians");
+    } else {
+        call FUNC(addCivInteractions);
+    };
+
 
     [{
         if (!isGameFocused || isGamePaused) exitWith {};

--- a/addons/interact/config.cpp
+++ b/addons/interact/config.cpp
@@ -6,7 +6,14 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"grad_civs_main", "grad_civs_lifecycle", "ace_interaction", "ace_captives"};
+        requiredAddons[] = {
+            "grad_civs_main"
+            , "grad_civs_lifecycle"
+            #ifdef WITH_ACE3_DEPENDENCY
+                , "ace_interaction"
+                , "ace_captives"
+            #endif
+        };
         author = "AUTHOR";
         VERSION_CONFIG;
     };

--- a/addons/interact/functions/fnc_sm_activities_state_surrendered_enter.sqf
+++ b/addons/interact/functions/fnc_sm_activities_state_surrendered_enter.sqf
@@ -7,7 +7,10 @@ if !(isNull _pointingPlayer) then {
 };
 
 _this setVariable ["grad_civs_surrenderTime", CBA_missionTime];
-[_this, true] call ACE_captives_fnc_setSurrendered;
+
+if (!isNil "ACE_captives_fnc_setSurrendered") then {
+	[_this, true] call ACE_captives_fnc_setSurrendered;
+};
 
 // the issue is that after dismounting, unit will sprint around. "doStop" does not seem to reliably and immediately work
 _this disableAI "MOVE";

--- a/addons/interact/functions/fnc_sm_activities_state_surrendered_exit.sqf
+++ b/addons/interact/functions/fnc_sm_activities_state_surrendered_exit.sqf
@@ -2,6 +2,10 @@
 
 _this enableAI "ANIM";
 _this enableAI "MOVE";
-[_this, false] call ACE_captives_fnc_setSurrendered;
+
+if (!isNil "ACE_captives_fnc_setSurrendered") then {
+    [_this, false] call ACE_captives_fnc_setSurrendered;
+};
+
 _this setVariable ["grad_civs_surrenderTime", nil];
 _this setVariable [QGVAR(pointingPlayer), nil];

--- a/addons/mimikry/config.cpp
+++ b/addons/mimikry/config.cpp
@@ -6,7 +6,13 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"CBA_Extended_EventHandlers", "ace_common", "grad_civs_activities"};
+        requiredAddons[] = {
+            "CBA_Extended_EventHandlers"
+            #ifdef WITH_ACE3_DEPENDENCY
+                , "ace_common"
+            #endif
+            , "grad_civs_activities"
+        };
         author = "AUTHOR";
         VERSION_CONFIG;
     };

--- a/addons/mimikry/functions/fnc_showCivHint.sqf
+++ b/addons/mimikry/functions/fnc_showCivHint.sqf
@@ -9,5 +9,7 @@ if (_structured == "") then {
     _structured = _plain;
 };
 
-[_structured] call ace_common_fnc_displayTextStructured;
+if (!isNil "ace_common_fnc_displayTextStructured") then {
+    [_structured] call ace_common_fnc_displayTextStructured;
+};
 systemChat _plain;


### PR DESCRIPTION
some things do not work without ACE, but there you go....

fixes #140 

NOTE: there is no `#define WITH_ACE3_DEPENDENCY` anywhere, but I'm still using `#ifdef WITH_ACE3_DEPENDENCY` in configs to mark the ACE things that are  being used in the respective addon