### PR TITLE
Run postInit when CBA_SettingsInitialized has been triggered

### DIFF
--- a/addons/activities/XEH_postInit.sqf
+++ b/addons/activities/XEH_postInit.sqf
@@ -1,18 +1,20 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+	if (!(EGVAR(main,enabled))) exitWith {};
 
-[] call FUNC(initCommonEventhandlers);
+	[] call FUNC(initCommonEventhandlers);
 
-if (isServer || CBA_isHeadlessClient) then {
-	["lifecycle", ["lfc_life"], FUNC(sm_emotions)] call EFUNC(common,augmentStateMachine);
-	["lifecycle", ["lfc_life"], FUNC(sm_activities)] call EFUNC(common,augmentStateMachine);
-	[
-		QEGVAR(lifecycle,civ_added), 
-		{
+	if (isServer || CBA_isHeadlessClient) then {
+		["lifecycle", ["lfc_life"], FUNC(sm_emotions)] call EFUNC(common,augmentStateMachine);
+		["lifecycle", ["lfc_life"], FUNC(sm_activities)] call EFUNC(common,augmentStateMachine);
+		[
+			QEGVAR(lifecycle,civ_added), 
 			{
-				[_x] call FUNC(onCivAdded);			
-			} forEach _this;
-		}
-	] call CBA_fnc_addEventHandler;
-};
+				{
+					[_x] call FUNC(onCivAdded);			
+				} forEach _this;
+			}
+		] call CBA_fnc_addEventHandler;
+	};
+}] call CBA_fnc_addEventHandler;

--- a/addons/cars/XEH_postInit.sqf
+++ b/addons/cars/XEH_postInit.sqf
@@ -1,7 +1,9 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (isServer || CBA_isHeadlessClient) then {
-    ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
-};
+    if (isServer || CBA_isHeadlessClient) then {
+        ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/common/XEH_postInit.sqf
+++ b/addons/common/XEH_postInit.sqf
@@ -1,9 +1,11 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-[QGVAR(switchMove), {
-        params ["_unit", "_animation"];
-        _unit switchMove _animation;
-    }
-] call CBA_fnc_addEventHandler;
+    [QGVAR(switchMove), {
+            params ["_unit", "_animation"];
+            _unit switchMove _animation;
+        }
+    ] call CBA_fnc_addEventHandler;
+}] call CBA_fnc_addEventHandler;

--- a/addons/diagnostics/XEH_postInit.sqf
+++ b/addons/diagnostics/XEH_postInit.sqf
@@ -1,48 +1,50 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (hasInterface) then {
-    call FUNC(showOnMap);
-    call FUNC(showPointingHints);
-    call FUNC(showInfoLine);
-    call FUNC(showFps);
-};
+    if (hasInterface) then {
+        call FUNC(showOnMap);
+        call FUNC(showPointingHints);
+        call FUNC(showInfoLine);
+        call FUNC(showFps);
+    };
 
-if (isServer || CBA_isHeadlessClient) then {
-    GVAR(debugLoopHandle) = [{
-        params ["", "_handle"];
-        if (hasInterface && (!isGameFocused || isGamePaused)) exitWith {};
-        if (call EGVAR(lifecycle,EXITON)) exitWith {[_handle] call CBA_fnc_removePerFrameHandler};
-        if (GVAR(showInfoLine)) then {
-            { _x call FUNC(updateInfoLine); } forEach EGVAR(lifecycle,localCivs);
-        };
-    }, 1, []] call CBA_fnc_addPerFrameHandler;
-
-    [
-        {
-            if (GVAR(showFps)) then {
-                [QGVAR(fps), [clientOwner, diag_fps, count EGVAR(lifecycle,localCivs)]] call CBA_fnc_globalEvent;
+    if (isServer || CBA_isHeadlessClient) then {
+        GVAR(debugLoopHandle) = [{
+            params ["", "_handle"];
+            if (hasInterface && (!isGameFocused || isGamePaused)) exitWith {};
+            if (call EGVAR(lifecycle,EXITON)) exitWith {[_handle] call CBA_fnc_removePerFrameHandler};
+            if (GVAR(showInfoLine)) then {
+                { _x call FUNC(updateInfoLine); } forEach EGVAR(lifecycle,localCivs);
             };
-        },
-        2,
-        []
-    ] call CBA_fnc_addPerFrameHandler;
-};
+        }, 1, []] call CBA_fnc_addPerFrameHandler;
 
-if (isServer) then {
-    [
-        QEGVAR(lifecycle,civ_added),
-        {
+        [
             {
-                private _civ = _x;
-                _civ setVariable [QGVAR(localAt), owner _civ, true];
-                _civ addEventHandler ["Local", {
-                    params ["_civ", ""];
-                    _civ setVariable [QGVAR(localAt), owner _civ, true];
-                }];
-            } forEach _this;
+                if (GVAR(showFps)) then {
+                    [QGVAR(fps), [clientOwner, diag_fps, count EGVAR(lifecycle,localCivs)]] call CBA_fnc_globalEvent;
+                };
+            },
+            2,
+            []
+        ] call CBA_fnc_addPerFrameHandler;
+    };
 
-        }
-   ] call CBA_fnc_addEventHandler;
-};
+    if (isServer) then {
+        [
+            QEGVAR(lifecycle,civ_added),
+            {
+                {
+                    private _civ = _x;
+                    _civ setVariable [QGVAR(localAt), owner _civ, true];
+                    _civ addEventHandler ["Local", {
+                        params ["_civ", ""];
+                        _civ setVariable [QGVAR(localAt), owner _civ, true];
+                    }];
+                } forEach _this;
+
+            }
+        ] call CBA_fnc_addEventHandler;
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/gta/XEH_postInit.sqf
+++ b/addons/gta/XEH_postInit.sqf
@@ -1,11 +1,13 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (!(GVAR(enabled))) exitWith {};
+    if (!(GVAR(enabled))) exitWith {};
 
-if (hasInterface) then {
-    player addEventHandler ["GetInMan", FUNC(onGetInMan)];
-    player addEventHandler ["GetOutMan", FUNC(onGetOutMan)];
-    player addEventHandler ["SeatSwitchedMan", FUNC(onSeatSwitchedMan)];
-};
+    if (hasInterface) then {
+        player addEventHandler ["GetInMan", FUNC(onGetInMan)];
+        player addEventHandler ["GetOutMan", FUNC(onGetOutMan)];
+        player addEventHandler ["SeatSwitchedMan", FUNC(onSeatSwitchedMan)];
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/interact/XEH_postInit.sqf
+++ b/addons/interact/XEH_postInit.sqf
@@ -1,31 +1,33 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (hasInterface) then {
-    call FUNC(aceInteractWrapper);
-    if (isNil "ace_interact_menu_fnc_createAction") then {
-        WARNING("ACE interact not loaded - this limits interaction with civilians");
-    } else {
-        call FUNC(addCivInteractions);
+    if (hasInterface) then {
+        call FUNC(aceInteractWrapper);
+        if (isNil "ace_interact_menu_fnc_createAction") then {
+            WARNING("ACE interact not loaded - this limits interaction with civilians");
+        } else {
+            call FUNC(addCivInteractions);
+        };
+
+
+        [{
+            if (!isGameFocused || isGamePaused) exitWith {};
+            [] call FUNC(checkWeaponOnCivilianPointer);
+        }, 0.5, []] call CBA_fnc_addPerFrameHandler;
+        private _playerUnit = call CBA_fnc_currentUnit;
+        _playerUnit addEventHandler ["GetInMan", FUNC(vehicleSeatHandler)];
+        _playerUnit addEventHandler ["SeatSwitchedMan", FUNC(vehicleSeatHandler)];
+        _playerUnit addEventHandler ["GetOutMan", FUNC(vehicleSeatHandler)];
+        _playerUnit addEventHandler ["Killed", { FUNC(vehicleSeatHandler) }];
+        _playerUnit addEventHandler ["Respawn", { FUNC(vehicleSeatHandler) }];
+        [] call FUNC(vehicleSeatHandler);
     };
 
+    [] call FUNC(addInteractEventHandlers);
 
-    [{
-        if (!isGameFocused || isGamePaused) exitWith {};
-        [] call FUNC(checkWeaponOnCivilianPointer);
-    }, 0.5, []] call CBA_fnc_addPerFrameHandler;
-    private _playerUnit = call CBA_fnc_currentUnit;
-    _playerUnit addEventHandler ["GetInMan", FUNC(vehicleSeatHandler)];
-    _playerUnit addEventHandler ["SeatSwitchedMan", FUNC(vehicleSeatHandler)];
-    _playerUnit addEventHandler ["GetOutMan", FUNC(vehicleSeatHandler)];
-    _playerUnit addEventHandler ["Killed", { FUNC(vehicleSeatHandler) }];
-    _playerUnit addEventHandler ["Respawn", { FUNC(vehicleSeatHandler) }];
-    [] call FUNC(vehicleSeatHandler);
-};
-
-[] call FUNC(addInteractEventHandlers);
-
-if (isServer || CBA_isHeadlessClient) then {
-    ["activities", ["act_business"], FUNC(sm_activities)] call EFUNC(common,augmentStateMachine);
-};
+    if (isServer || CBA_isHeadlessClient) then {
+        ["activities", ["act_business"], FUNC(sm_activities)] call EFUNC(common,augmentStateMachine);
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/lifecycle/XEH_postInit.sqf
+++ b/addons/lifecycle/XEH_postInit.sqf
@@ -1,39 +1,41 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-ISNILS(GVAR(EXITON), {false});
+    ISNILS(GVAR(EXITON), {false});
 
-if (isServer || CBA_isHeadlessClient) then {
-    [] call FUNC(initHCs);
-};
+    if (isServer || CBA_isHeadlessClient) then {
+        [] call FUNC(initHCs);
+    };
 
-[
-    QGVAR(do_dismiss_civ),
-    {
+    [
+        QGVAR(do_dismiss_civ),
+        {
+            params [
+                ["_object", objNull, [objNull, grpNull]]
+            ];
+            if (!((leader _object) in GVAR(localCivs))) exitWith {
+                INFO_2("not dismissing %1 (%2) as it is not local civ led", _object, typeName _object);
+            };
+
+            if (_object isEqualType grpNull) then {
+                [_object] call FUNC(dismissGroup);
+            } else {
+                [_object] call FUNC(dismissCiv);
+            };
+        }
+    ] call CBA_fnc_addEventHandler;
+
+
+    ["ace_unconscious", {
         params [
-            ["_object", objNull, [objNull, grpNull]]
+            ["_unit", objNull, [objNull]], 
+            ["_isUnconscious", true, [true]]
         ];
-        if (!((leader _object) in GVAR(localCivs))) exitWith {
-            INFO_2("not dismissing %1 (%2) as it is not local civ led", _object, typeName _object);
-        };
 
-        if (_object isEqualType grpNull) then {
-            [_object] call FUNC(dismissGroup);
-        } else {
-            [_object] call FUNC(dismissCiv);
-        };
-    }
-] call CBA_fnc_addEventHandler;
+        private _eventName = if (_isUnconscious) then {QGVAR(unconscious)} else {QGVAR(conscious)};
+        [_eventName, [_unit], _unit] call CBA_fnc_targetEvent;
 
-
-["ace_unconscious", {
-    params [
-        ["_unit", objNull, [objNull]], 
-        ["_isUnconscious", true, [true]]
-    ];
-
-    private _eventName = if (_isUnconscious) then {QGVAR(unconscious)} else {QGVAR(conscious)};
-    [_eventName, [_unit], _unit] call CBA_fnc_targetEvent;
-
+    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/loadout/XEH_postInit.sqf
+++ b/addons/loadout/XEH_postInit.sqf
@@ -1,21 +1,23 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-[QEGVAR(lifecycle,civ_added), {    
-    {
-        private _civ = _x;
-        if (local _civ) then {
-            [_civ] call FUNC(civAddLoadout);
-        };
-    } forEach _this;
-}] call CBA_fnc_addEventHandler;
+    [QEGVAR(lifecycle,civ_added), {    
+        {
+            private _civ = _x;
+            if (local _civ) then {
+                [_civ] call FUNC(civAddLoadout);
+            };
+        } forEach _this;
+    }] call CBA_fnc_addEventHandler;
 
-[QGVAR(broadcastFace), {
-    params [
-        ["_unit", objNull, [objNull]],
-        ["_face", "", [""]]
-    ];
-    if (isNull _unit) exitWith {};
-    _unit setFace _face;
+    [QGVAR(broadcastFace), {
+        params [
+            ["_unit", objNull, [objNull]],
+            ["_face", "", [""]]
+        ];
+        if (isNull _unit) exitWith {};
+        _unit setFace _face;
+    }] call CBA_fnc_addEventHandler;
 }] call CBA_fnc_addEventHandler;

--- a/addons/main/XEH_postInit.sqf
+++ b/addons/main/XEH_postInit.sqf
@@ -1,8 +1,9 @@
 #include "script_component.hpp"
 
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {
+        INFO("GRAD civs is disabled. Good bye!");
+    };
 
-if (!(EGVAR(main,enabled))) exitWith {
-    INFO("GRAD civs is disabled. Good bye!");
-};
-
-INFO_3("I am a player: %1 | HC: %2 | Server: %3", hasInterface, CBA_isHeadlessClient, isServer);
+    INFO_3("I am a player: %1 | HC: %2 | Server: %3", hasInterface, CBA_isHeadlessClient, isServer);
+}] call CBA_fnc_addEventHandler;

--- a/addons/mimikry/XEH_postInit.sqf
+++ b/addons/mimikry/XEH_postInit.sqf
@@ -1,38 +1,40 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (!(GVAR(enabled))) exitWith {
-    INFO("module disabled. good bye.");
-};
+    if (!(GVAR(enabled))) exitWith {
+        INFO("module disabled. good bye.");
+    };
 
-if (hasInterface) then {
-    [] call FUNC(addEventHandlers);
+    if (hasInterface) then {
+        [] call FUNC(addEventHandlers);
 
-    GVAR(playerActsAsCiv) = false;
-    [
-        {
-            if (!isGameFocused || isGamePaused) exitWith {};
-            private _playerUnit = call CBA_fnc_currentUnit;
-            if !(alive _playerUnit) exitWith {};
-            private _playerIsCiv = false;
-            private _playerIsCiv = (side _playerUnit) isEqualTo civilian;
-            if !((lifeState _playerUnit) in ["HEALTHY", "INJURED"]) then {
-                // NOTE: incapacitated players are side civ which we dont want
-                _playerIsCiv = false;
-            };
+        GVAR(playerActsAsCiv) = false;
+        [
+            {
+                if (!isGameFocused || isGamePaused) exitWith {};
+                private _playerUnit = call CBA_fnc_currentUnit;
+                if !(alive _playerUnit) exitWith {};
+                private _playerIsCiv = false;
+                private _playerIsCiv = (side _playerUnit) isEqualTo civilian;
+                if !((lifeState _playerUnit) in ["HEALTHY", "INJURED"]) then {
+                    // NOTE: incapacitated players are side civ which we dont want
+                    _playerIsCiv = false;
+                };
 
-            if (GVAR(playerActsAsCiv) isEqualTo _playerIsCiv) exitWith {};
+                if (GVAR(playerActsAsCiv) isEqualTo _playerIsCiv) exitWith {};
 
-            if (_playerIsCiv) then {
-                ["you are CIVILIAN now"] call FUNC(showCivHint);
-            } else { if (GVAR(playerActsAsCiv)) then {
-                ["you are NO LONGER CIVILIAN"] call FUNC(showCivHint);
-            }};
-            GVAR(playerActsAsCiv) = _playerIsCiv;
-        },
-        5,
-        []
-    ] call CBA_fnc_addPerFrameHandler;
+                if (_playerIsCiv) then {
+                    ["you are CIVILIAN now"] call FUNC(showCivHint);
+                } else { if (GVAR(playerActsAsCiv)) then {
+                    ["you are NO LONGER CIVILIAN"] call FUNC(showCivHint);
+                }};
+                GVAR(playerActsAsCiv) = _playerIsCiv;
+            },
+            5,
+            []
+        ] call CBA_fnc_addPerFrameHandler;
 
-};
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/patrol/XEH_postInit.sqf
+++ b/addons/patrol/XEH_postInit.sqf
@@ -1,25 +1,27 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (isServer || CBA_isHeadlessClient) then {
-    [
-        QEGVAR(lifecycle,localSpawn),
-        {
-            ISNILS(GVAR(maxCivsOnFoot), GVAR(maxCivsOnFoot));
-            LOG("checking for maxCivsOnFoot / whether i am allowed to spawn more patrols");
-            if ((count (["patrol"] call EFUNC(lifecycle,getGlobalCivs))) < GVAR(maxCivsOnFoot)) then {
-                LOG("calling addFootsy");
-                [ALL_HUMAN_PLAYERS] call FUNC(addFootsy);
-            };
-        }
-    ] call CBA_fnc_addEventHandler;
+    if (isServer || CBA_isHeadlessClient) then {
+        [
+            QEGVAR(lifecycle,localSpawn),
+            {
+                ISNILS(GVAR(maxCivsOnFoot), GVAR(maxCivsOnFoot));
+                LOG("checking for maxCivsOnFoot / whether i am allowed to spawn more patrols");
+                if ((count (["patrol"] call EFUNC(lifecycle,getGlobalCivs))) < GVAR(maxCivsOnFoot)) then {
+                    LOG("calling addFootsy");
+                    [ALL_HUMAN_PLAYERS] call FUNC(addFootsy);
+                };
+            }
+        ] call CBA_fnc_addEventHandler;
 
-    private _spawnDistances = [GVAR(spawnDistancesOnFoot)] call EFUNC(common,parseCsv);
-    [
-        "patrol",
-        _spawnDistances#1 * 1.5
-    ] call EFUNC(common,registerCivTaskType);
+        private _spawnDistances = [GVAR(spawnDistancesOnFoot)] call EFUNC(common,parseCsv);
+        [
+            "patrol",
+            _spawnDistances#1 * 1.5
+        ] call EFUNC(common,registerCivTaskType);
 
-    ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
-};
+        ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/residents/XEH_postInit.sqf
+++ b/addons/residents/XEH_postInit.sqf
@@ -1,59 +1,61 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-GVAR(houseworkAnimationSetsInhouseNight) = [
-    "PRONE_INJURED_U1", // lies on back
-    "PRONE_INJURED_U2", // lies on back
-    "SIT_LOW_U" // sit on floor
-];
+    GVAR(houseworkAnimationSetsInhouseNight) = [
+        "PRONE_INJURED_U1", // lies on back
+        "PRONE_INJURED_U2", // lies on back
+        "SIT_LOW_U" // sit on floor
+    ];
 
-GVAR(houseworkAnimationSetsInhouseDay) = [
-    "STAND_U1", // stands bored
-    "STAND_U2", // stands bored
-    "STAND_U3", // stands bored
-    "GUARD", // hands back
-    "LISTEN_BRIEFING", // hands back
-    "REPAIR_VEH_KNEEL",
-    "REPAIR_VEH_STAND",
-    "KNEEL_TREAT",
-    "BRIEFING",
-    "BRIEFING_POINT_TABLE",
-    "REPAIR_VEH_PRONE", // lies on back
-    "SIT_LOW_U" // sit on floor
-];
+    GVAR(houseworkAnimationSetsInhouseDay) = [
+        "STAND_U1", // stands bored
+        "STAND_U2", // stands bored
+        "STAND_U3", // stands bored
+        "GUARD", // hands back
+        "LISTEN_BRIEFING", // hands back
+        "REPAIR_VEH_KNEEL",
+        "REPAIR_VEH_STAND",
+        "KNEEL_TREAT",
+        "BRIEFING",
+        "BRIEFING_POINT_TABLE",
+        "REPAIR_VEH_PRONE", // lies on back
+        "SIT_LOW_U" // sit on floor
+    ];
 
-GVAR(houseworkAnimationSetsOutdoors) = [
-    "STAND_U1", // stands bored
-    "STAND_U2", // stands bored
-    "STAND_U3", // stands bored
-    "WATCH", // looking left to right
-    "WATCH2", // more straight ahead
-    "GUARD", // hands back
-    "LISTEN_BRIEFING", // hands back
-    "REPAIR_VEH_KNEEL",
-    "KNEEL_TREAT"
-];
+    GVAR(houseworkAnimationSetsOutdoors) = [
+        "STAND_U1", // stands bored
+        "STAND_U2", // stands bored
+        "STAND_U3", // stands bored
+        "WATCH", // looking left to right
+        "WATCH2", // more straight ahead
+        "GUARD", // hands back
+        "LISTEN_BRIEFING", // hands back
+        "REPAIR_VEH_KNEEL",
+        "KNEEL_TREAT"
+    ];
 
-GVAR(houseworkTimesDay) = [5, 30, 120];
-GVAR(houseworkTimesNight) = [120, 240, 900];
+    GVAR(houseworkTimesDay) = [5, 30, 120];
+    GVAR(houseworkTimesNight) = [120, 240, 900];
 
-if (isServer || CBA_isHeadlessClient) then {
-    [
-        QEGVAR(lifecycle,localSpawn),
-        {
-            ISNILS(GVAR(maxCivsResidents), GVAR(maxCivsResidents));
-            if ((count (["reside"] call EFUNC(lifecycle,getGlobalCivs))) < GVAR(maxCivsResidents)) then {
-                [ALL_HUMAN_PLAYERS] call FUNC(addResident);
-            };
-        }
-    ] call CBA_fnc_addEventHandler;
+    if (isServer || CBA_isHeadlessClient) then {
+        [
+            QEGVAR(lifecycle,localSpawn),
+            {
+                ISNILS(GVAR(maxCivsResidents), GVAR(maxCivsResidents));
+                if ((count (["reside"] call EFUNC(lifecycle,getGlobalCivs))) < GVAR(maxCivsResidents)) then {
+                    [ALL_HUMAN_PLAYERS] call FUNC(addResident);
+                };
+            }
+        ] call CBA_fnc_addEventHandler;
 
-    private _spawnDistances = [GVAR(spawnDistancesResidents)] call EFUNC(common,parseCsv);
-    [
-        "reside",
-        _spawnDistances#1 * 1.2
-    ] call EFUNC(common,registerCivTaskType);
+        private _spawnDistances = [GVAR(spawnDistancesResidents)] call EFUNC(common,parseCsv);
+        [
+            "reside",
+            _spawnDistances#1 * 1.2
+        ] call EFUNC(common,registerCivTaskType);
 
-    ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
-};
+        ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/transit/XEH_postInit.sqf
+++ b/addons/transit/XEH_postInit.sqf
@@ -1,17 +1,19 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (isServer || CBA_isHeadlessClient) then {
-    [
-        QEGVAR(lifecycle,localSpawn),
-        {
-            if ((count (["transit"] call EFUNC(cars,getGlobalVehicles))) < GVAR(maxVehiclesInTransit)) then {
-                [] call FUNC(spawnSomething);
-            };
-        }
-    ] call CBA_fnc_addEventHandler;
+    if (isServer || CBA_isHeadlessClient) then {
+        [
+            QEGVAR(lifecycle,localSpawn),
+            {
+                if ((count (["transit"] call EFUNC(cars,getGlobalVehicles))) < GVAR(maxVehiclesInTransit)) then {
+                    [] call FUNC(spawnSomething);
+                };
+            }
+        ] call CBA_fnc_addEventHandler;
 
-    ["business", ["bus_mountUp"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
-    ["lifecycle", ["lfc_life", "lfc_despawn"], FUNC(sm_lifecycle)] call EFUNC(common,augmentStateMachine);
-};
+        ["business", ["bus_mountUp"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
+        ["lifecycle", ["lfc_life", "lfc_despawn"], FUNC(sm_lifecycle)] call EFUNC(common,augmentStateMachine);
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/voyage/XEH_postInit.sqf
+++ b/addons/voyage/XEH_postInit.sqf
@@ -1,23 +1,25 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (isServer || CBA_isHeadlessClient) then {
-    [
-        QEGVAR(lifecycle,localSpawn),
-        {
-            private _maxCivsInVehicles = GVAR(maxCivsInVehicles);
-            if ((count (["voyage"] call EFUNC(lifecycle,getGlobalCivs))) < _maxCivsInVehicles) then {
-                [ALL_HUMAN_PLAYERS] call FUNC(addCarCrew);
-            };
-        }
-    ] call CBA_fnc_addEventHandler;
+    if (isServer || CBA_isHeadlessClient) then {
+        [
+            QEGVAR(lifecycle,localSpawn),
+            {
+                private _maxCivsInVehicles = GVAR(maxCivsInVehicles);
+                if ((count (["voyage"] call EFUNC(lifecycle,getGlobalCivs))) < _maxCivsInVehicles) then {
+                    [ALL_HUMAN_PLAYERS] call FUNC(addCarCrew);
+                };
+            }
+        ] call CBA_fnc_addEventHandler;
 
-    private _spawnDistances = [GVAR(spawnDistancesInVehicles)] call EFUNC(common,parseCsv);
-    [
-        "voyage",
-        _spawnDistances#1 * 1.5
-    ] call EFUNC(common,registerCivTaskType);
+        private _spawnDistances = [GVAR(spawnDistancesInVehicles)] call EFUNC(common,parseCsv);
+        [
+            "voyage",
+            _spawnDistances#1 * 1.5
+        ] call EFUNC(common,registerCivTaskType);
 
-    ["business", ["bus_mountUp"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
-};
+        ["business", ["bus_mountUp"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -1,7 +1,9 @@
 #include "script_component.hpp"
 
-if (!(EGVAR(main,enabled))) exitWith {};
+["CBA_SettingsInitialized", {
+    if (!(EGVAR(main,enabled))) exitWith {};
 
-if (hasInterface) then {
-    [] call FUNC(setupZeusModules);
-};
+    if (hasInterface) then {
+        [] call FUNC(setupZeusModules);
+    };
+}] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
Prevents race conditions whereby the `grad_civs_main_enabled` flag could be initialized after the scripts are executed.

Tested:
* Locally to ensure addons are still invoked
* Dedicated server with headless client

Dedicated server test scenarios:
1. Starting Headless Client 5 minutes after server start.
2. Starting headless client with dedicated server, prior to mission start

In both scenarios, where the dedicated server and headless client both owned the civilian objects, civilians did spawn successfully and there were no issues with evaluating the value of `grad_civs_main_enabled`.

I haven't tested bug #125 but this change may also resolve that problem.