### PR TITLE
Add ability to override civClasses

### DIFF
--- a/addons/common/README.md
+++ b/addons/common/README.md
@@ -29,13 +29,35 @@ From existing Population Zones, subtract areas  where civilian may *not* spawn.
 
 ## API
 
-### `grad_civs_common_fnc_addExclusionZone` and `grad_civs_common_fnc_addPopulationZone`
+## grad_civs_common_fnc_addPopulationZone
 
-Whitelist areas or prevent civilians from spawning in areas (area = trigger area).
+Whitelist areas to allow civilians to spawn in those areas (area = trigger area).
+
+**Syntax**
+```sqf
+[_trigger, _civClasses, _vehicleClasses] call grad_civs_common_fnc_addPopulationZone
+```
+
+## grad_civs_common_fnc_addExclusionZone
+
+Prevent civilians from being spawned in specific areas.
+
+**Syntax**
+```sqf
+[_trigger] call grad_civs_common_fnc_addExclusionZone;
+```
+
+**Alternative syntax**
+```sqf
+[
+    [
+        [x, y, z], // Coordinates
+        150, // X Radius
+        150, // Y Radius
+        0, // Angle
+        false // True if area is Rectangle. False for Ellipse
+    ]
+] call grad_civs_common_fnc_addExclusionZone;
+```
 
 *known issues: pathing through area is not checked. To minimize that problem, define exclusionZones with large diameter.*
-
-#### Syntax
-
-* `[_trigger, _civClasses, _vehicleClasses] call grad_civs_common_fnc_addPopulationZone` , then forbid parts of them using `[_area] call grad_civs_common_fnc_addExclusionZone`
-* `[_trigger] call grad_civs_common_fnc_addExclusionZone;`  

--- a/addons/common/README.md
+++ b/addons/common/README.md
@@ -61,3 +61,19 @@ Prevent civilians from being spawned in specific areas.
 ```
 
 *known issues: pathing through area is not checked. To minimize that problem, define exclusionZones with large diameter.*
+
+## grad_civs_common_fnc_removeExclusionZone
+
+Remove a zone from the exclusion list to allow civilians to spawn there again.
+
+**Syntax**
+```sqf
+[_trigger] call grad_civs_common_fnc_removeExclusionZone
+```
+
+**Alternative syntax**
+```sqf
+[
+    [x, y, z] // Coordinates for an existing exclusion zone. X, Y and Z must be an exact match.
+] call grad_civs_common_fnc_removeExclusionZone;
+```

--- a/addons/common/XEH_PREP.hpp
+++ b/addons/common/XEH_PREP.hpp
@@ -13,3 +13,4 @@ PREP(module_populationZone);
 PREP(nowPlusSeconds);
 PREP(parseCsv);
 PREP(registerCivTaskType);
+PREP(removeExclusionZone);

--- a/addons/common/functions/fnc_removeExclusionZone.sqf
+++ b/addons/common/functions/fnc_removeExclusionZone.sqf
@@ -1,0 +1,15 @@
+#include "..\script_component.hpp"
+
+params ["_area"];
+
+ISNILS(GVAR(EXCLUSION_ZONES), []);
+
+private _zoneIdx = GVAR(EXCLUSION_ZONES) findIf {
+	_area isEqualTo (if(_x isEqualType []) then [{_x#0}, {_x}]);
+};
+
+if(_zoneIdx isEqualTo -1) exitWith{};
+
+GVAR(EXCLUSION_ZONES) deleteAt _zoneIdx;
+
+INFO_1("removed exclusion zone %1", _area);

--- a/addons/lifecycle/README.md
+++ b/addons/lifecycle/README.md
@@ -16,7 +16,22 @@ Controls all spawning & despawning of civilians, as well as incapacitation & dea
 
 ## API
 
-### Events 
+## grad_civs_lifecycle_fnc_setCivilians
+
+Sets the classnames that civilians will spawn as. Overwrites value from CBA settings. Execute globally
+
+#### Example
+
+```sqf
+private _civClasses = ["C_Man_01"];
+[_civClasses] call grad_civs_lifecycle_fnc_setCivilians
+```
+
+Parameter   | Explanation
+------------|-------------------------------------------------------------
+civClasses  | Array - All classnames that civilians will spawn as.
+
+## Events 
 
 **NOTE:** event names are prefixed with `grad_civs_lifecycle_`
 

--- a/addons/lifecycle/XEH_PREP.hpp
+++ b/addons/lifecycle/XEH_PREP.hpp
@@ -14,6 +14,7 @@ PREP(globalSpawnPass);
 PREP(initHCs);
 PREP(isInDistanceFromOtherPlayers);
 PREP(overclockStateMachines);
+PREP(setCivilians);
 PREP(sm_lifecycle);
 PREP(sm_lifecycle_state_death_enter);
 PREP(sm_lifecycle_state_despawn_enter);

--- a/addons/lifecycle/functions/fnc_setCivilians.sqf
+++ b/addons/lifecycle/functions/fnc_setCivilians.sqf
@@ -1,0 +1,9 @@
+#include "..\script_component.hpp"
+
+params [
+	["_value",[], [[]]] // array of vehicle class names
+];
+
+assert(_value isEqualTypeAll "");
+
+[QGVAR(civClasses), str _value, 1, "mission"] call CBA_settings_fnc_set;

--- a/addons/lifecycle/functions/fnc_setCivilians.sqf
+++ b/addons/lifecycle/functions/fnc_setCivilians.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 
 params [
-	["_value",[], [[]]] // array of vehicle class names
+	["_value",[], [[]]] // array of civilian unit class names
 ];
 
 assert(_value isEqualTypeAll "");


### PR DESCRIPTION
Adds a function, similar to `setVehicles`, that allows you to override the civilian classnames without directly manipulating the global variable.

This also updates the documentation of `grad_civs_common_fnc_addPopulationZone` to provide an alternative syntax for adding exclusion zones programmatically.