### PR TITLE
Add Killed Event Handler to vehicles

### DIFF
--- a/addons/cars/README.md
+++ b/addons/cars/README.md
@@ -29,3 +29,12 @@ private _vehicles = ["C_Van_01_Fuel_F"];
 Parameter | Explanation
 ----------|-------------------------------------------------------------
 vehicles  | Array - All classnames of vehicles that civilians may drive.
+
+
+### Events
+
+#### grad_civs_cars_vehKilled
+
+```sqf 
+["grad_civs_cars_vehKilled", { params ["_deathPos", "_killer", "_vehicle_"]; }] call CBA_fnc_addEventHandler;
+```

--- a/addons/cars/functions/fnc_spawnVehicle.sqf
+++ b/addons/cars/functions/fnc_spawnVehicle.sqf
@@ -23,6 +23,15 @@ _veh addEventHandler [
      }
  ];
 
+ _veh addEventHandler [
+    "Killed",
+    {
+        params ["_unit", "_killer"];
+
+        ["grad_civs_cars_vehKilled", [getPos _unit, _killer, _unit]] call CBA_fnc_globalEvent;
+    }
+ ];
+
 private _animalChance = GVAR(animalTransportChance);
 [_veh, _animalChance] call FUNC(loadAnimals);
 


### PR DESCRIPTION
Resolves #163 

Raised as a draft PR since I wasn't sure whether you'd prefer to keep the event logic in a state machine similar to the `grad_civs_civKilled` event. Feedback and suggestions are welcome.