### PR TITLE
Post-release bugfixes

### DIFF
--- a/addons/cars/functions/fnc_setVehicles.sqf
+++ b/addons/cars/functions/fnc_setVehicles.sqf
@@ -6,4 +6,4 @@ params [
 
 assert(_value isEqualTypeAll "");
 
-[QGVAR(vehicles), str _value, 1, "mission"] call CBA_settings_fnc_set;
+[QGVAR(vehicles), str _value, 1, "server", true] call CBA_settings_fnc_set;

--- a/addons/lifecycle/functions/fnc_setCivilians.sqf
+++ b/addons/lifecycle/functions/fnc_setCivilians.sqf
@@ -6,4 +6,4 @@ params [
 
 assert(_value isEqualTypeAll "");
 
-[QGVAR(civClasses), str _value, 1, "mission"] call CBA_settings_fnc_set;
+[QGVAR(civClasses), str _value, 1, "server", true] call CBA_settings_fnc_set;

--- a/addons/residents/functions/fnc_sm_business_state_housework_enter.sqf
+++ b/addons/residents/functions/fnc_sm_business_state_housework_enter.sqf
@@ -5,7 +5,7 @@
 private _isSleepingTime = _this call EFUNC(activities,isSleepingTime);
 
 private _house = _this getVariable ["grad_civs_home", objNull];
-_this setVariable [QGVAR(housework_time), random if (_isSleepingTime) then {GVAR(houseworkTimesNight)} else {GVAR(houseworkTimesDay)}];
+_this setVariable [QGVAR(housework_time), random (if (_isSleepingTime) then [{GVAR(houseworkTimesNight)},{GVAR(houseworkTimesDay)}])];
 _this call EFUNC(activities,forceEmotionSpeed);
 
 if (isNull _house) exitWith {


### PR DESCRIPTION
Fixes the housework_enter state whereby the `random` evaluation would fail due to the if statement not being wrapped. Also changed to use the alternative syntax for if-else values.

Updated the `setCivilians` and `setVehicles` functions to update CBA at a server level while storing the value. I've found that using `"mission"` doesn't broadcast the value to headless clients that are JIP.