### PR TITLE
add global speed limit

### DIFF
--- a/addons/cars/functions/fnc_initConfig.sqf
+++ b/addons/cars/functions/fnc_initConfig.sqf
@@ -54,3 +54,13 @@ private _settingsGroup = ["GRAD Civilians", "7) cars - basic settings for civili
     false
 ] call CBA_fnc_addSetting;
 
+[
+    QGVAR(globalSpeedLimit),
+    "SLIDER",
+    "Vehicle speed limit in m/s",
+    _settingsGroup,
+    [-1, 100, 20, 0, false],
+    false,
+    {},
+    false
+] call CBA_fnc_addSetting;

--- a/addons/cars/functions/fnc_initConfig.sqf
+++ b/addons/cars/functions/fnc_initConfig.sqf
@@ -57,7 +57,7 @@ private _settingsGroup = ["GRAD Civilians", "7) cars - basic settings for civili
 [
     QGVAR(globalSpeedLimit),
     "SLIDER",
-    "Vehicle speed limit in m/s",
+    "Vehicle speed limit in km/h",
     _settingsGroup,
     [-1, 100, 20, 0, false],
     false,

--- a/addons/cars/functions/fnc_initConfig.sqf
+++ b/addons/cars/functions/fnc_initConfig.sqf
@@ -59,7 +59,7 @@ private _settingsGroup = ["GRAD Civilians", "7) cars - basic settings for civili
     "SLIDER",
     "Vehicle speed limit in km/h",
     _settingsGroup,
-    [-1, 360, 20, 0, false],
+    [-1, 360, 50, 0, false],
     false,
     {},
     false

--- a/addons/cars/functions/fnc_initConfig.sqf
+++ b/addons/cars/functions/fnc_initConfig.sqf
@@ -59,7 +59,7 @@ private _settingsGroup = ["GRAD Civilians", "7) cars - basic settings for civili
     "SLIDER",
     "Vehicle speed limit in km/h",
     _settingsGroup,
-    [-1, 100, 20, 0, false],
+    [-1, 360, 20, 0, false],
     false,
     {},
     false

--- a/addons/diagnostics/functions/fnc_showInfoLine.sqf
+++ b/addons/diagnostics/functions/fnc_showInfoLine.sqf
@@ -35,7 +35,13 @@ ISNILS(GVAR(userActionIds), []);
             switch (GVAR(civStateFormat)) do {
                 case 0: {""};
                 case 1: {_x getVariable [QGVAR(infoLine),"<no info found. is debug mode enabled where the civs are local?>"]; };
-                case 2: {format["%1 | speedmode: %2 %3", _x, speedMode _x, if (leader _x == _x) then {"(is leader)"} else {""}]; };
+                case 2: {
+                    private _veh = vehicle _x;
+                    private _driver = driver _veh;
+                    if ((_veh != _x) && (_driver != _x)) exitWith { "x" };
+
+                    format["%1 | %2km/h in speedmode: %3 %4", _x, round speed _veh, speedMode _x, if (leader _x == _x) then {"(is leader)"} else {""}];
+                };
                 case 3: {format["%1 | %2 guns point at him", _x, _x getVariable [QEGVAR(interact,pointedAtCount), 0]]};
                 case 4: {format["%1 | is local at %2", _x, _x getVariable [QGVAR(localAt), 0]]};
                 case 5: {format["%1 | %2 %3 %4 | stopped: %5, unitReady: %6", _x, behaviour _x, combatMode _x, speedMode _x, stopped _x, unitReady _x]};
@@ -105,7 +111,7 @@ if (GVAR(showInfoLine)) then {
     GVAR(userActionIds) = [
         ["<t color='#3333FF'>civstate format: empty</t>", 0] call _addCivAction,
         ["<t color='#3333FF'>civstate format: infoLine</t>", 1] call _addCivAction,
-        ["<t color='#3333FF'>civstate format: speedmode</t>", 2] call _addCivAction,
+        ["<t color='#3333FF'>civstate format: speed</t>", 2] call _addCivAction,
         ["<t color='#3333FF'>civstate format: guns</t>", 3] call _addCivAction,
         ["<t color='#3333FF'>civstate format: locality</t>", 4] call _addCivAction,
         ["<t color='#3333FF'>civstate format: behaviour</t>", 5] call _addCivAction,

--- a/addons/transit/functions/fnc_sm_business_state_transit_loop.sqf
+++ b/addons/transit/functions/fnc_sm_business_state_transit_loop.sqf
@@ -9,3 +9,5 @@ if (isNull _group) exitWith {
     private _livedAs = _this getVariable ["grad_civs_livedAs", str _this];
     WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(lifecycle,localCivs) find _this, getPos _this);
 };
+
+(vehicle _this) forceSpeed EGVAR(cars,globalSpeedLimit);

--- a/addons/transit/functions/fnc_sm_business_state_transit_loop.sqf
+++ b/addons/transit/functions/fnc_sm_business_state_transit_loop.sqf
@@ -10,4 +10,4 @@ if (isNull _group) exitWith {
     WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(lifecycle,localCivs) find _this, getPos _this);
 };
 
-(vehicle _this) forceSpeed EGVAR(cars,globalSpeedLimit);
+(vehicle _this) limitSpeed EGVAR(cars,globalSpeedLimit);

--- a/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
@@ -6,4 +6,4 @@ if (isNull _group) exitWith {
     WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(lifecycle,localCivs) find _this, getPos _this);
 };
 
-(vehicle _this) forceSpeed EGVAR(cars,globalSpeedLimit);
+(vehicle _this) limitSpeed EGVAR(cars,globalSpeedLimit);

--- a/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
@@ -5,3 +5,5 @@ if (isNull _group) exitWith {
     private _livedAs = _this getVariable ["grad_civs_livedAs", str _this];
     WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(lifecycle,localCivs) find _this, getPos _this);
 };
+
+(vehicle _this) forceSpeed EGVAR(cars,globalSpeedLimit);


### PR DESCRIPTION
with the aim of reducing accidents,

~~this changes vehicles from driving in "limited" speed mode (which varies depending on max vehicle speed) to using a fixed absolute speed limit for orientation.~~

* set a globally defined speed limit on vehicles using `limitSpeed` 
* config var `grad_civs_cars_globalSpeedLimit`
    * defaults to 50 km/h
    * set to -1 to disable
* changes to speed limit will take immediate effect
* NOTE: cannot use `forceSpeed` as vehicles would be forbidden from braking for tight turns
* fixes #169 (further ideas to improve that behaviour should be put into separate tickets)

