### PR TITLE
Local speed limit

### DIFF
--- a/addons/cars/README.md
+++ b/addons/cars/README.md
@@ -1,6 +1,6 @@
 # grad\_civs\_cars
 
-Basic handling of civs driving cars. 
+Basic handling of civs driving cars.
 
 As a user, see transit and voyage modules to actually get civs driving on the streets.
 
@@ -12,6 +12,8 @@ animalTransportChance    | 0.4           | Probability that a suitable vehicle w
 animalTransportVehicles  | []            | optional list of class names whitelisting vehicles that are allowed to carry animals
 automaticVehicleGroupSize| 1             | Allow vehicles to be filled according to capacity, ignoring *initialGroupSize* (0,1).
 vehicles                 | ["C_Van_01_fuel_F", "C_Hatchback_01_F", "C_Offroad_02_unarmed_F", "C_Truck_02_fuel_F", "C_Truck_02_covered_F", "C_Offroad_01_F", "C_SUV_01_F", "C_Van_01_transport_F", "C_Van_01_box_F"]            | All classnames of vehicles that civilians may drive.
+globalSpeedLimit         | 50            | Speed limit for civilian vehicles in km/h
+townSpeedLimit           | 30            | Speed limit for civilian vehicles in km/h while in the area of a city or village Location
 
 ## API
 
@@ -35,13 +37,23 @@ vehicles  | Array - All classnames of vehicles that civilians may drive.
 
 #### grad_civs_cars_car_added
 
-```sqf 
+```sqf
 ["grad_civs_cars_car_added", { params ["_vehicle"]; }] call CBA_fnc_addEventHandler;
 ```
 
 
 #### grad_civs_cars_vehKilled
 
-```sqf 
+```sqf
 ["grad_civs_cars_vehKilled", { params ["_deathPos", "_killer", "_vehicle"]; }] call CBA_fnc_addEventHandler;
 ```
+
+### Global variables
+
+#### grad_civs_cars_customSpeedLimits
+
+You may define speed limits by setting the `grad_civs_cars_customSpeedLimits` array.
+
+Each entry must be an array with two entries: a [Location](https://community.bistudio.com/wiki/Location) and a number (the speed limit in km/h).
+
+This array must be local on the machines running the civs, i.e. server and/or headless clients.

--- a/addons/cars/XEH_PREP.hpp
+++ b/addons/cars/XEH_PREP.hpp
@@ -1,8 +1,11 @@
+PREP(determineTownLocations);
+PREP(determineSpeedLimits);
 PREP(dismountCondition);
 PREP(getGlobalVehicles);
 PREP(getGroupVehicle);
 PREP(initConfig);
 PREP(loadAnimals);
+PREP(pfh_speedLimit);
 PREP(setGroupVehicle);
 PREP(setVehicles);
 PREP(sm_business_state_dismount_enter);

--- a/addons/cars/XEH_postInit.sqf
+++ b/addons/cars/XEH_postInit.sqf
@@ -5,5 +5,24 @@
 
     if (isServer || CBA_isHeadlessClient) then {
         ["business", ["bus_rally"], FUNC(sm_business)] call EFUNC(common,augmentStateMachine);
+
+        ISNILS(GVAR(pfh_speedLimit_interval), EGVAR(lifecycle,minCivUpdateTime));
+        GVAR(pfh_speedLimit) = [FUNC(pfh_speedLimit), GVAR(pfh_speedLimit_interval)] call CBA_fnc_addPerFrameHandler;
+
+        ISNILS(GVAR(localCars), []);
+        [QGVAR(car_added), {
+            params ["_veh"];
+            if (local _veh) then {
+                GVAR(localCars) pushBackUnique _veh;
+            };
+        }] call CBA_fnc_addEventHandler;
+        [QGVAR(vehKilled), {
+            params ["_veh"];
+            GVAR(localCars) = GVAR(localCars) - [_veh];
+        }] call CBA_fnc_addEventHandler;
+        GVAR(pfh_groomCarsArray) = [{
+            GVAR(localCars) = GVAR(localCars) select {!(isNull _x)};
+        }, 5] call CBA_fnc_addPerFrameHandler;
+
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/cars/functions/fnc_determineSpeedLimits.sqf
+++ b/addons/cars/functions/fnc_determineSpeedLimits.sqf
@@ -1,0 +1,6 @@
+#include "..\script_component.hpp"
+
+ISNILS(GVAR(customSpeedLimits), []); // Array<(Location, number)>
+ISNILS(GVAR(townSpeedLimits), ([] call FUNC(determineTownLocations)) apply {[ARR_2(_x, GVAR(townSpeedLimit))]});
+
+GVAR(townSpeedLimits) + GVAR(customSpeedLimits)

--- a/addons/cars/functions/fnc_determineTownLocations.sqf
+++ b/addons/cars/functions/fnc_determineTownLocations.sqf
@@ -1,0 +1,10 @@
+#include "..\script_component.hpp"
+
+private _radius = worldSize / 2;
+private _center = [_radius, _radius];
+private _townLocationTypes = ["NameCity", "NameCityCapital", "NameVillage", "FlatAreaCity", "FlatAreaCitySmall"];
+nearestLocations [
+    _center,
+    _townLocationTypes,
+    _radius
+]

--- a/addons/cars/functions/fnc_initConfig.sqf
+++ b/addons/cars/functions/fnc_initConfig.sqf
@@ -59,7 +59,18 @@ private _settingsGroup = ["GRAD Civilians", "7) cars - basic settings for civili
     "SLIDER",
     "Vehicle speed limit in km/h",
     _settingsGroup,
-    [-1, 360, 50, 0, false],
+    [0, 360, 50, 0, false],
+    false,
+    {},
+    false
+] call CBA_fnc_addSetting;
+
+[
+    QGVAR(townSpeedLimit),
+    "SLIDER",
+    "Vehicle speed limit within towns in km/h",
+    _settingsGroup,
+    [0, 360, 30, 0, false],
     false,
     {},
     false

--- a/addons/cars/functions/fnc_pfh_speedLimit.sqf
+++ b/addons/cars/functions/fnc_pfh_speedLimit.sqf
@@ -1,0 +1,19 @@
+#include "..\script_component.hpp"
+
+private _speedLimits = call FUNC(determineSpeedLimits);
+
+{
+    _x setVariable [QGVAR(speedLimit), GVAR(globalSpeedLimit)];
+} forEach GVAR(localCars);
+
+{
+    _x params ["_location", "_speedLimit"];
+    private _affectedCars = GVAR(localCars) inAreaArray _location;
+    {
+        _x setVariable [QGVAR(speedLimit), _speedLimit];
+    } forEach _affectedCars;
+} forEach _speedLimits;
+
+{
+    _x limitSpeed (_x getVariable [QGVAR(speedLimit), GVAR(globalSpeedLimit)]);
+} forEach GVAR(localCars);

--- a/addons/cars/functions/fnc_spawnVehicle.sqf
+++ b/addons/cars/functions/fnc_spawnVehicle.sqf
@@ -28,7 +28,7 @@ _veh addEventHandler [
     {
         params ["_unit", "_killer"];
 
-        ["grad_civs_cars_vehKilled", [getPos _unit, _killer, _unit]] call CBA_fnc_globalEvent;
+        [QGVAR(vehKilled), [getPos _unit, _killer, _unit]] call CBA_fnc_globalEvent;
     }
  ];
 

--- a/addons/diagnostics/README.md
+++ b/addons/diagnostics/README.md
@@ -1,6 +1,8 @@
 # grad\_civs\_diagnostics
 
-Debugging GUI stuff
+Debugging GUI stuff.
+
+A lot of it only works in Singleplayer, as much of the relevant data is local where the civs are, and they're local on server or HCs.
 
 ## Settings
 
@@ -11,4 +13,6 @@ showFps                  | false         | Show server & HC fps
 showOnMap                | false         | Show civs on map
 showInfoLine             | false         | Show detailed info line on civilian
 showPinkArrows           | false         | Create 3D arrows over civ heads
+showSpawnAttempts        | false         | Show short-lived markers on map to debug spawning
+showSpeedLimitsOnMap     | false         | Show locations + corresponding speed limit on map
 showMisc                 | false         | Miscellaneous stuff

--- a/addons/diagnostics/XEH_PREP.hpp
+++ b/addons/diagnostics/XEH_PREP.hpp
@@ -1,4 +1,5 @@
 PREP(drawFlyScarePoly);
+PREP(drawSpeedLimitsOnMap);
 PREP(initConfig);
 PREP(showFps);
 PREP(showFlyScarePoly);
@@ -14,5 +15,6 @@ PREP(showPinkArrows_arrowDelete);
 PREP(showPinkArrows_arrowEnsure);
 PREP(showPointingHints);
 PREP(showSpawnAttempts);
+PREP(showSpeedLimitsOnMap);
 PREP(tempMarker);
 PREP(updateInfoLine);

--- a/addons/diagnostics/functions/fnc_drawSpeedLimitsOnMap.sqf
+++ b/addons/diagnostics/functions/fnc_drawSpeedLimitsOnMap.sqf
@@ -1,0 +1,37 @@
+#include "..\script_component.hpp"
+
+params [
+    ["_mode", "update", [""]]
+];
+
+ISNILS(GVAR(speedLimitMarkers), []);
+{
+    deleteMarkerLocal _x;
+} forEach GVAR(speedLimitMarkers);
+GVAR(speedLimitMarkers) = [];
+
+if (_mode == "delete") exitWith {};
+
+private _speedLimits = call EFUNC(cars,determineSpeedLimits);
+
+{
+    _x params ["_location", "_speedLimit"];
+
+    private _circle = createMarkerLocal [format ["speed_limit_town_%1_circle", _forEachIndex], position _location];
+    _circle setMarkerShapeLocal "ELLIPSE";
+    _circle setMarkerSizeLocal (size _location);
+    _circle setMarkerBrushLocal "SolidBorder";
+    _circle setMarkerColorLocal "ColorBlue";
+    _circle setMarkerAlphaLocal 0.5;
+
+    private _text = createMarkerLocal [format ["speed_limit_town_%1_text", _forEachIndex], position _location];
+    _text setMarkerShapeLocal "ICON";
+    _text setMarkerTypeLocal "mil_circle_noShadow";
+    _text setMarkerColorLocal "ColorBlue";
+    _text setMarkerTextLocal (format ["%1 km/h", _speedLimit]);
+
+
+    GVAR(speedLimitMarkers) pushBack _circle;
+    GVAR(speedLimitMarkers) pushBack _text;
+
+} forEach _speedLimits;

--- a/addons/diagnostics/functions/fnc_initConfig.sqf
+++ b/addons/diagnostics/functions/fnc_initConfig.sqf
@@ -60,6 +60,17 @@ private _settingsGroup = ["GRAD Civilians", "c) diagnostics - debugging info"];
 ] call CBA_fnc_addSetting;
 
 [
+    QGVAR(showSpeedLimitsOnMap),
+    "CHECKBOX",
+    "Show speed limits on map",
+    _settingsGroup,
+    false,
+    false,
+    FUNC(showSpeedLimitsOnMap),
+    false
+] call CBA_fnc_addSetting;
+
+[
     QGVAR(showMisc),
     "CHECKBOX",
     "Miscellaneous stuff",
@@ -70,7 +81,6 @@ private _settingsGroup = ["GRAD Civilians", "c) diagnostics - debugging info"];
         { deleteVehicle _x } forEach GVAR(dangerPolyGroundHelpers);
         [] call FUNC(showHonkAtArea);
         [] call FUNC(showFlyScarePoly);
-
     },
     false
 ] call CBA_fnc_addSetting;

--- a/addons/diagnostics/functions/fnc_showInfoLine.sqf
+++ b/addons/diagnostics/functions/fnc_showInfoLine.sqf
@@ -40,7 +40,13 @@ ISNILS(GVAR(userActionIds), []);
                     private _driver = driver _veh;
                     if ((_veh != _x) && (_driver != _x)) exitWith { "x" };
 
-                    format["%1 | %2km/h in speedmode: %3 %4", _x, round speed _veh, speedMode _x, if (leader _x == _x) then {"(is leader)"} else {""}];
+                    format["%1 | %2 / %3 km/h in speedmode: %4 %5",
+                        _x,
+                        round speed _veh,
+                        round (_veh getVariable [QEGVAR(cars,speedLimit), -1]),
+                        speedMode _x,
+                        if (leader _x == _x) then {"(is leader)"} else {""}
+                    ];
                 };
                 case 3: {format["%1 | %2 guns point at him", _x, _x getVariable [QEGVAR(interact,pointedAtCount), 0]]};
                 case 4: {format["%1 | is local at %2", _x, _x getVariable [QGVAR(localAt), 0]]};

--- a/addons/diagnostics/functions/fnc_showSpeedLimitsOnMap.sqf
+++ b/addons/diagnostics/functions/fnc_showSpeedLimitsOnMap.sqf
@@ -1,0 +1,22 @@
+#include "..\script_component.hpp"
+
+ISNILS(GVAR(speedLimitsPfh), -1);
+
+if (!GVAR(showSpeedLimitsOnMap)) exitWith {
+    [GVAR(speedLimitsPfh)] call CBA_fnc_removePerFrameHandler;
+    GVAR(speedLimitsPfh) = -1;
+    ["delete"] call FUNC(drawSpeedLimitsOnMap);
+};
+
+if (GVAR(speedLimitsPfh) != -1) exitWith {
+    WARNING("showSpeedLimitsOnMap already has pfh, not adding another one");
+};
+
+GVAR(speedLimitsPfh) = [
+    {
+        if (!isGameFocused || isGamePaused) exitWith {};
+        ["update"] call FUNC(drawSpeedLimitsOnMap);
+    },
+    2,
+    []
+] call CBA_fnc_addPerFrameHandler;

--- a/addons/transit/functions/fnc_sm_business_state_transit_loop.sqf
+++ b/addons/transit/functions/fnc_sm_business_state_transit_loop.sqf
@@ -9,5 +9,3 @@ if (isNull _group) exitWith {
     private _livedAs = _this getVariable ["grad_civs_livedAs", str _this];
     WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(lifecycle,localCivs) find _this, getPos _this);
 };
-
-(vehicle _this) limitSpeed EGVAR(cars,globalSpeedLimit);

--- a/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
+++ b/addons/voyage/functions/fnc_sm_business_state_voyage_loop.sqf
@@ -5,5 +5,3 @@ if (isNull _group) exitWith {
     private _livedAs = _this getVariable ["grad_civs_livedAs", str _this];
     WARNING_5("unit %1 (type %2) in voyage loop has no group. will ignore. alive %3 index %4 pos %5", _livedAs, typeof _this, alive _this, EGVAR(lifecycle,localCivs) find _this, getPos _this);
 };
-
-(vehicle _this) limitSpeed EGVAR(cars,globalSpeedLimit);


### PR DESCRIPTION
extending the functionality of #170  : add another speed limit option for towns.

it's a bit rough, as it uses location data (locations are circles, and cities are not necessarily circlish), but it works nicely as a first approximation.

default speed limit within towns is 30km/h

fallout from this change includes:
* an array of local civilian vehicles
* local speed limit indicator in the debug "show info line: speed" display
* add diagnostics option to show speed limits on map
* a variable on the vehicles denoting their current speed limit
* for scripting : a global var containing custom speed limits (gets read contonuously). speed limits are applied after town speed limits in the order they appear in this GVAR.
* speed limits are now set from the cars addon, which nicely keeps that whole functionality from the other behavioral stuff in voyagers / transit addons