### PR TITLE
Lifecycle: Reduce RPT Spam

### DIFF
--- a/addons/lifecycle/XEH_preInit.sqf
+++ b/addons/lifecycle/XEH_preInit.sqf
@@ -30,5 +30,8 @@ GVAR(excludedParentClasses) = [
 	"Land_i_Barracks_V1_F" // yes, is parent for others!
 ];
 
+GVAR(shouldWarnSpawnPass) = true;
+GVAR(shouldWarnDespawnAbstain) = true;
+
 [] call FUNC(initConfig);
 

--- a/addons/lifecycle/XEH_preInit.sqf
+++ b/addons/lifecycle/XEH_preInit.sqf
@@ -30,7 +30,7 @@ GVAR(excludedParentClasses) = [
 	"Land_i_Barracks_V1_F" // yes, is parent for others!
 ];
 
-GVAR(shouldWarnSpawnPass) = true;
+GVAR(shouldWarnSpawnAbstain) = true;
 GVAR(shouldWarnDespawnAbstain) = true;
 
 [] call FUNC(initConfig);

--- a/addons/lifecycle/functions/fnc_localSpawnPass.sqf
+++ b/addons/lifecycle/functions/fnc_localSpawnPass.sqf
@@ -1,8 +1,11 @@
 #include "..\script_component.hpp"
 
-if ((ALL_HUMAN_PLAYERS isEqualTo []) && (GVAR(spawnOnlyWithPlayers))) exitWith {
-    INFO("no human players connected, will abstain from spawning civilians")
+if ((ALL_HUMAN_PLAYERS isEqualTo []) && (GVAR(spawnOnlyWithPlayers)) && (GVAR(shouldWarnSpawnPass))) exitWith {
+    INFO("no human players connected, will abstain from spawning civilians");
+    GVAR(shouldWarnSpawnPass) = false;
 };
+
+GVAR(shouldWarnSpawnPass) = true;
 
 private _minCivUpdateTime = GVAR(minCivUpdateTime);
 private _minFps = GVAR(minCivOwnerFps);

--- a/addons/lifecycle/functions/fnc_localSpawnPass.sqf
+++ b/addons/lifecycle/functions/fnc_localSpawnPass.sqf
@@ -1,11 +1,11 @@
 #include "..\script_component.hpp"
 
-if ((ALL_HUMAN_PLAYERS isEqualTo []) && (GVAR(spawnOnlyWithPlayers)) && (GVAR(shouldWarnSpawnPass))) exitWith {
+if ((ALL_HUMAN_PLAYERS isEqualTo []) && (GVAR(spawnOnlyWithPlayers)) && (GVAR(shouldWarnSpawnAbstain))) exitWith {
     INFO("no human players connected, will abstain from spawning civilians");
-    GVAR(shouldWarnSpawnPass) = false;
+    GVAR(shouldWarnSpawnAbstain) = false;
 };
 
-GVAR(shouldWarnSpawnPass) = true;
+GVAR(shouldWarnSpawnAbstain) = true;
 
 private _minCivUpdateTime = GVAR(minCivUpdateTime);
 private _minFps = GVAR(minCivOwnerFps);

--- a/addons/lifecycle/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
+++ b/addons/lifecycle/functions/fnc_sm_lifecycle_trans_life_despawn_condition.sqf
@@ -20,8 +20,12 @@ if ((count ALL_HUMAN_PLAYERS > 0) || (GVAR(spawnOnlyWithPlayers))) then {
         INFO_1("despawning civ %1 based on distance", _this);
         _tooDistantFromPlayers = true;
     };
+    GVAR(shouldWarnDespawnAbstain) = true;
 } else {
-    INFO("no human players connected, but civs allowed - will abstain from despawning civilians based on player distance");
+    if (GVAR(shouldWarnDespawnAbstain)) then {
+        INFO("no human players connected, but civs allowed - will abstain from despawning civilians based on player distance");
+        GVAR(shouldWarnDespawnAbstain) = false;
+    };
 };
 
 _tooDistantFromPlayers || {_this call _despawnCondition}


### PR DESCRIPTION
Only prints the abstain / pass messages the first time to avoid RPT spam

This is very significant for servers with `persistent = 1`