### PR TITLE
Gracefully handle when findSpawnRoadSegment returns objNull

### DIFF
--- a/.github/workflows/ace_sqf_validator.yml
+++ b/.github/workflows/ace_sqf_validator.yml
@@ -24,10 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        wget https://raw.githubusercontent.com/acemod/ACE3/master/tools/sqf_validator.py
-        sed -i '117d' sqf_validator.py
-        sed -i '116d' sqf_validator.py
-        sed -i '115d' sqf_validator.py
     - name: Lint
       run: |
-        python3 sqf_validator.py
+        python3 tools/sqf_validator.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       id: build
 
     - name: Upload artifact
-      uses: actions/upload-artifact@1.0.0
+      uses: actions/upload-artifact@v4
       with:
         name: 'grad_civs'
         path: ${{ steps.build.outputs.zip_path }}

--- a/addons/voyage/functions/fnc_addCarCrew.sqf
+++ b/addons/voyage/functions/fnc_addCarCrew.sqf
@@ -32,7 +32,7 @@ private _spawnPositionRoad = [
     _vehicleSpawnDistanceMax
 ] call FUNC(findSpawnRoadSegment);
 
-if (_spawnPositionRoad isEqualTo false) exitWith {
+if (_spawnPositionRoad isEqualTo false || _spawnPositionRoad isEqualTo objNull) exitWith {
     INFO("could not find spawn position for car at this time");
     grpNull
 };

--- a/addons/voyage/functions/fnc_addCarCrew.sqf
+++ b/addons/voyage/functions/fnc_addCarCrew.sqf
@@ -32,7 +32,7 @@ private _spawnPositionRoad = [
     _vehicleSpawnDistanceMax
 ] call FUNC(findSpawnRoadSegment);
 
-if (_spawnPositionRoad isEqualTo false || _spawnPositionRoad isEqualTo objNull) exitWith {
+if (_spawnPositionRoad isEqualTo false) exitWith {
     INFO("could not find spawn position for car at this time");
     grpNull
 };

--- a/addons/voyage/functions/fnc_findSpawnRoadSegment.sqf
+++ b/addons/voyage/functions/fnc_findSpawnRoadSegment.sqf
@@ -4,6 +4,6 @@
 
 params ["_allPlayers", "_minSpawnDistance", "_maxSpawnDistance"];
 
-if (_allPlayers isEqualTo []) exitWith {LOG("_allPlayers is empty"); objNull};
+if (_allPlayers isEqualTo []) exitWith {LOG("_allPlayers is empty"); false};
 
 ([ALL_HUMAN_PLAYERS, _minSpawnDistance, _maxSpawnDistance, "road"] call EFUNC(lifecycle,findSpawnPosition));

--- a/tools/sqf_validator.py
+++ b/tools/sqf_validator.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+import fnmatch
+import os
+import re
+import sys
+import argparse
+
+def validKeyWordAfterCode(content, index):
+    keyWords = ["for", "do", "count", "each", "forEach", "else", "and", "not", "isEqualTo", "in", "call", "spawn", "execVM", "catch", "param", "select", "apply", "findIf", "remoteExec"];
+    for word in keyWords:
+        try:
+            return True
+        except:
+            pass
+    return False
+
+def check_sqf_syntax(filepath):
+    bad_count_file = 0
+
+    with open(filepath, 'r', encoding='utf-8', errors='ignore') as file:
+        content = file.read()
+
+        # Store all brackets we find in this file, so we can validate everything on the end
+        brackets_list = []
+
+        # To check if we are in a comment block
+        isInCommentBlock = False
+        checkIfInComment = False
+        # Used in case we are in a line comment (//)
+        ignoreTillEndOfLine = False
+        # Used in case we are in a comment block (/* */). This is true if we detect a * inside a comment block.
+        # If the next character is a /, it means we end our comment block.
+        checkIfNextIsClosingBlock = False
+
+        # We ignore everything inside a string
+        isInString = False
+        # Used to store the starting type of a string, so we can match that to the end of a string
+        inStringType = ''
+
+        lastIsCurlyBrace = False
+        checkForSemicolon = False
+        onlyWhitespace = True
+
+        # Extra information so we know what line we find errors at
+        lineNumber = 1
+
+        indexOfCharacter = 0
+        # Parse all characters in the content of this file to search for potential errors
+        for c in content:
+            if (lastIsCurlyBrace):
+                lastIsCurlyBrace = False
+                # Test generates false positives with binary commands that take CODE as 2nd arg (e.g. findIf)
+                checkForSemicolon = not re.search('findIf', content, re.IGNORECASE)
+
+            if c == '\n': # Keeping track of our line numbers
+                onlyWhitespace = True # reset so we can see if # is for a preprocessor command
+                lineNumber += 1 # so we can print accurate line number information when we detect a possible error
+            if (isInString): # while we are in a string, we can ignore everything else, except the end of the string
+                if (c == inStringType):
+                    isInString = False
+            # if we are not in a comment block, we will check if we are at the start of one or count the () {} and []
+            elif (isInCommentBlock == False):
+
+                # This means we have encountered a /, so we are now checking if this is an inline comment or a comment block
+                if (checkIfInComment):
+                    checkIfInComment = False
+                    if c == '*': # if the next character after / is a *, we are at the start of a comment block
+                        isInCommentBlock = True
+                    elif (c == '/'): # Otherwise, will check if we are in an line comment
+                        ignoreTillEndOfLine = True # and an line comment is a / followed by another / (//) We won't care about anything that comes after it
+
+                if (isInCommentBlock == False):
+                    if (ignoreTillEndOfLine): # we are in a line comment, just continue going through the characters until we find an end of line
+                        if (c == '\n'):
+                            ignoreTillEndOfLine = False
+                    else: # validate brackets
+                        if (c == '"' or c == "'"):
+                            isInString = True
+                            inStringType = c
+                        elif (c == '#' and onlyWhitespace):
+                            ignoreTillEndOfLine = True
+                        elif (c == '/'):
+                            checkIfInComment = True
+                        elif (c == '('):
+                            brackets_list.append('(')
+                        elif (c == ')'):
+                            if (brackets_list[-1] in ['{', '[']):
+                                print("ERROR: Possible missing round bracket ')' detected at {0} Line number: {1}".format(filepath,lineNumber))
+                                bad_count_file += 1
+                            brackets_list.append(')')
+                        elif (c == '['):
+                            brackets_list.append('[')
+                        elif (c == ']'):
+                            if (brackets_list[-1] in ['{', '(']):
+                                print("ERROR: Possible missing square bracket ']' detected at {0} Line number: {1}".format(filepath,lineNumber))
+                                bad_count_file += 1
+                            brackets_list.append(']')
+                        elif (c == '{'):
+                            brackets_list.append('{')
+                        elif (c == '}'):
+                            lastIsCurlyBrace = True
+                            if (brackets_list[-1] in ['(', '[']):
+                                print("ERROR: Possible missing curly brace '}}' detected at {0} Line number: {1}".format(filepath,lineNumber))
+                                bad_count_file += 1
+                            brackets_list.append('}')
+
+                        if (c not in [' ', '\t', '\n']):
+                            onlyWhitespace = False
+
+                        if (checkForSemicolon):
+                            if (c not in [' ', '\t', '\n', '/']): # keep reading until no white space or comments
+                                checkForSemicolon = False
+                                if (c not in [']', ')', '}', ';', ',', '&', '!', '|', '='] and not validKeyWordAfterCode(content, indexOfCharacter)): # , 'f', 'd', 'c', 'e', 'a', 'n', 'i']):
+                                    print("ERROR: Possible missing semicolon ';' detected at {0} Line number: {1}".format(filepath,lineNumber))
+                                    bad_count_file += 1
+
+            else: # Look for the end of our comment block
+                if (c == '*'):
+                    checkIfNextIsClosingBlock = True
+                elif (checkIfNextIsClosingBlock):
+                    if (c == '/'):
+                        isInCommentBlock = False
+                    elif (c != '*'):
+                        checkIfNextIsClosingBlock = False
+            indexOfCharacter += 1
+
+        if brackets_list.count('[') != brackets_list.count(']'):
+            print("ERROR: A possible missing square bracket [ or ] in file {0} [ = {1} ] = {2}".format(filepath,brackets_list.count('['),brackets_list.count(']')))
+            bad_count_file += 1
+        if brackets_list.count('(') != brackets_list.count(')'):
+            print("ERROR: A possible missing round bracket ( or ) in file {0} ( = {1} ) = {2}".format(filepath,brackets_list.count('('),brackets_list.count(')')))
+            bad_count_file += 1
+        if brackets_list.count('{') != brackets_list.count('}'):
+            print("ERROR: A possible missing curly brace {{ or }} in file {0} {{ = {1} }} = {2}".format(filepath,brackets_list.count('{'),brackets_list.count('}')))
+            bad_count_file += 1
+        pattern = re.compile('\s*(/\*[\s\S]+?\*/)\s*#include')
+        if pattern.match(content):
+            print("ERROR: A found #include after block comment in file {0}".format(filepath))
+            bad_count_file += 1
+        if ("functions" in filepath):
+            if (content.startswith("#include \"script_component.hpp\"")):
+                print(f"ERROR: Using old script_component.hpp in {filepath}")
+                bad_count_file += 1
+
+
+
+    return bad_count_file
+
+def main():
+
+    print("Validating SQF")
+
+    sqf_list = []
+    bad_count = 0
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-m','--module', help='only search specified module addon folder', required=False, default="")
+    args = parser.parse_args()
+
+    for folder in ['addons', 'optionals']:
+        # Allow running from root directory as well as from inside the tools directory
+        rootDir = "../" + folder
+        if (os.path.exists(folder)):
+            rootDir = folder
+
+        for root, _, filenames in os.walk(rootDir + '/' + args.module):
+            for filename in fnmatch.filter(filenames, '*.sqf'):
+                sqf_list.append(os.path.join(root, filename))
+
+    for filename in sqf_list:
+        bad_count = bad_count + check_sqf_syntax(filename)
+
+
+    print("------\nChecked {0} files\nErrors detected: {1}".format(len(sqf_list), bad_count))
+    if (bad_count == 0):
+        print("SQF validation PASSED")
+    else:
+        print("SQF validation FAILED")
+
+    return bad_count
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This script spams the RPT file with errors when the object returned from `findSpawnRoadSegment` is `objNull` because it only checks for a value `false` before attempting to index the HashMap that would be returned in the happy-path scenario